### PR TITLE
Fix linux library name

### DIFF
--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -90,7 +90,7 @@ mod vk {
 lazy_static! {
     static ref VK_LIB: shared_library::dynamic_library::DynamicLibrary = {
         #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan-1.so") }
+        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
         let path = get_path();
         shared_library::dynamic_library::DynamicLibrary::open(Some(path)).unwrap()
     };


### PR DESCRIPTION
Currently the code searches for "libvulkan-1.so", but vulkan library (at least on my system) is called "libvulkan.so.1". 