### PR TITLE
Improve clear values handling when creating framebuffer

### DIFF
--- a/vulkano/examples/teapot.rs
+++ b/vulkano/examples/teapot.rs
@@ -215,7 +215,7 @@ fn main() {
     let command_buffers = framebuffers.iter().map(|framebuffer| {
         vulkano::command_buffer::PrimaryCommandBufferBuilder::new(&cb_pool)
             .draw_inline(&renderpass, &framebuffer, renderpass::ClearValues {
-                 color: [0.0, 0.0, 1.0, 1.0].into(),
+                 color: [0.0, 0.0, 1.0, 1.0],
                  depth: 1.0,
              })
             .draw_indexed(&pipeline, (&vertex_buffer, &normals_buffer), &index_buffer,

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -168,7 +168,7 @@ macro_rules! formats {
         }
 
         $(
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, Copy, Clone, Default)]
             #[allow(missing_docs)]
             #[allow(non_camel_case_types)]
             pub struct $name;


### PR DESCRIPTION
- The `ClearValues` struct now takes template parameters of type `Into<RealTy>` instead of `RealTy`. See the teapot example for the consequence.
- When the format is relaxed, it is now correctly checked at runtime.
