### PR TITLE
Rework the library loading system

### DIFF
--- a/vk-sys/src/functions.rs
+++ b/vk-sys/src/functions.rs
@@ -32,8 +32,8 @@ macro_rules! ptrs {
         unsafe impl Sync for $struct_name {}
 
         impl $struct_name {
-            pub fn load<F>(f: F) -> $struct_name
-                where F: Fn(&CStr) -> *const c_void
+            pub fn load<F>(mut f: F) -> $struct_name
+                where F: FnMut(&CStr) -> *const c_void
             {
                 $struct_name {
                     $(

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -11,7 +11,7 @@ use std::ffi::CString;
 use std::ptr;
 
 use OomError;
-use VK_ENTRY;
+use instance::loader;
 use vk;
 use check_errors;
 
@@ -65,13 +65,15 @@ macro_rules! instance_extensions {
         impl $sname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<$sname, OomError> {
+                let entry_points = loader::entry_points().unwrap();     // TODO: return proper error
+
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
                     let mut num = 0;
-                    try!(check_errors(VK_ENTRY.EnumerateInstanceExtensionProperties(
+                    try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
                         ptr::null(), &mut num, ptr::null_mut())));
                     
                     let mut properties = Vec::with_capacity(num as usize);
-                    try!(check_errors(VK_ENTRY.EnumerateInstanceExtensionProperties(
+                    try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
                         ptr::null(), &mut num, properties.as_mut_ptr())));
                     properties.set_len(num as usize);
                     properties

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -15,18 +15,20 @@ use std::vec::IntoIter;
 use check_errors;
 use OomError;
 use vk;
-use VK_ENTRY;
+use instance::loader;
 use version::Version;
 
 /// Queries the list of layers that are available when creating an instance.
 pub fn layers_list() -> Result<LayersIterator, OomError> {
     unsafe {
+        let entry_points = loader::entry_points().unwrap();     // TODO: return proper error
+
         let mut num = 0;
-        try!(check_errors(VK_ENTRY.EnumerateInstanceLayerProperties(&mut num, ptr::null_mut())));
+        try!(check_errors(entry_points.EnumerateInstanceLayerProperties(&mut num, ptr::null_mut())));
 
         let mut layers: Vec<vk::LayerProperties> = Vec::with_capacity(num as usize);
-        try!(check_errors(VK_ENTRY.EnumerateInstanceLayerProperties(&mut num,
-                                                                    layers.as_mut_ptr())));
+        try!(check_errors(entry_points.EnumerateInstanceLayerProperties(&mut num,
+                                                                        layers.as_mut_ptr())));
         layers.set_len(num as usize);
 
         Ok(LayersIterator {

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::error;
+use std::fmt;
+use std::mem;
+use std::path::Path;
+use std::ptr;
+
+use shared_library;
+use vk;
+
+lazy_static! {
+    static ref VK_LIB: Result<shared_library::dynamic_library::DynamicLibrary, LoadingError> = {
+        #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
+        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
+        let path = get_path();
+        shared_library::dynamic_library::DynamicLibrary::open(Some(path))
+                                    .map_err(|err| LoadingError::LibraryLoadFailure(err))
+    };
+
+    static ref VK_STATIC: Result<vk::Static, LoadingError> = {
+        match *VK_LIB {
+            Ok(ref lib) => {
+                let mut err = None;
+                let result = vk::Static::load(|name| unsafe {
+                    let name = name.to_str().unwrap();
+                    match lib.symbol(name) {
+                        Ok(s) => s,
+                        Err(_) => {     // TODO: return error?
+                            err = Some(LoadingError::MissingEntryPoint(name.to_owned()));
+                            ptr::null()
+                        }
+                    }
+                });
+
+                if let Some(err) = err {
+                    Err(err)
+                } else {
+                    Ok(result)
+                }
+            },
+            Err(ref err) => Err(err.clone()),
+        }
+    };
+
+    static ref VK_ENTRY: Result<vk::EntryPoints, LoadingError> = {
+        match *VK_STATIC {
+            Ok(ref lib) => {
+                // At this point we assume that if one of the functions fails to load, it is an
+                // implementation bug and not a real-life situation that could be handled by
+                // an error.
+                Ok(vk::EntryPoints::load(|name| unsafe {
+                    mem::transmute(lib.GetInstanceProcAddr(0, name.as_ptr()))
+                }))
+            },
+            Err(ref err) => Err(err.clone()),
+        }
+    };
+}
+
+/// Returns the collection of static functions from the Vulkan loader, or an error if failed to
+/// open the loader.
+pub fn static_functions() -> Result<&'static vk::Static, LoadingError> {
+    VK_STATIC.as_ref().map_err(|err| err.clone())
+}
+
+/// Returns the collection of Vulkan entry points from the Vulkan loader, or an error if failed to
+/// open the loader.
+pub fn entry_points() -> Result<&'static vk::EntryPoints, LoadingError> {
+    VK_ENTRY.as_ref().map_err(|err| err.clone())
+}
+
+/// Error that can happen when loading the Vulkan loader.
+#[derive(Debug, Clone)]
+pub enum LoadingError {
+    /// Failed to load the Vulkan shared library.
+    LibraryLoadFailure(String),         // TODO: meh for error type, but this needs changes in shared_library
+
+    /// One of the entry points required to be supported by the Vulkan implementation is missing.
+    MissingEntryPoint(String),
+}
+
+impl error::Error for LoadingError {
+    #[inline]
+    fn description(&self) -> &str {
+        match *self {
+            LoadingError::LibraryLoadFailure(_) => {
+                "failed to load the Vulkan shared library"
+            },
+            LoadingError::MissingEntryPoint(_) => {
+                "one of the entry points required to be supported by the Vulkan implementation \
+                 is missing"
+            },
+        }
+    }
+
+    /*#[inline]
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            LoadingError::LibraryLoadFailure(ref err) => Some(err),
+            _ => None
+        }
+    }*/
+}
+
+impl fmt::Display for LoadingError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", error::Error::description(self))
+    }
+}

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -62,9 +62,11 @@ pub use self::instance::Limits;
 pub use self::layers::layers_list;
 pub use self::layers::LayerProperties;
 pub use self::layers::LayersIterator;
+pub use self::loader::LoadingError;
 
 pub mod debug;
 
 mod extensions;
 mod instance;
 mod layers;
+mod loader;

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -76,9 +76,7 @@ pub mod sync;
 
 use std::error;
 use std::fmt;
-use std::mem;
 use std::ops::Deref;
-use std::path::Path;
 use std::sync::Arc;
 use std::sync::MutexGuard;
 
@@ -88,27 +86,6 @@ mod vk {
     #![allow(non_snake_case)]
     #![allow(non_camel_case_types)]
     include!(concat!(env!("OUT_DIR"), "/vk_bindings.rs"));
-}
-
-lazy_static! {
-    static ref VK_LIB: shared_library::dynamic_library::DynamicLibrary = {
-        #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
-        let path = get_path();
-        shared_library::dynamic_library::DynamicLibrary::open(Some(path)).unwrap()
-    };
-
-    static ref VK_STATIC: vk::Static = {
-        vk::Static::load(|name| unsafe {
-            VK_LIB.symbol(name.to_str().unwrap()).unwrap()      // TODO: error handling
-        })
-    };
-
-    static ref VK_ENTRY: vk::EntryPoints = {
-        vk::EntryPoints::load(|name| unsafe {
-            mem::transmute(VK_STATIC.GetInstanceProcAddr(0, name.as_ptr()))
-        })
-    };
 }
 
 /// Alternative to the `Deref` trait. Contrary to `Deref`, must always return the same object.


### PR DESCRIPTION
Moves it out of `lib.rs`. An error is now properly returned when vulkan.so or vulkan.dll fails to load.

For the moment the error is simply unwrapped in the parts of the library that use entry points. In the future it should be returned to the user.

cc #15 