### PR TITLE
Remove support for device layers

### DIFF
--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -44,8 +44,8 @@ fn main() {
         .. vulkano::device::DeviceExtensions::none()
     };
     let (device, mut queues) = vulkano::device::Device::new(&physical, physical.supported_features(),
-                                                        &device_ext, &[], [(queue, 0.5)].iter().cloned())
-                                                                .expect("failed to create device");
+                                                            &device_ext, [(queue, 0.5)].iter().cloned())
+                               .expect("failed to create device");
     let queue = queues.next().unwrap();
 
     let (swapchain, images) = {

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -49,8 +49,8 @@ fn main() {
     };
 
     let (device, mut queues) = vulkano::device::Device::new(&physical, physical.supported_features(),
-                                                        &device_ext, None, [(queue, 0.5)].iter().cloned())
-                                                                .expect("failed to create device");
+                                                            &device_ext, [(queue, 0.5)].iter().cloned())
+                               .expect("failed to create device");
     let queue = queues.next().unwrap();
 
     let (swapchain, images) = {

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -147,7 +147,7 @@ fn main() {
             .. vulkano::device::DeviceExtensions::none()
         };
 
-        Device::new(&physical, physical.supported_features(), &device_ext, None,
+        Device::new(&physical, physical.supported_features(), &device_ext,
                     [(queue, 0.5)].iter().cloned()).expect("failed to create device")
     };
 

--- a/vulkano/src/tests.rs
+++ b/vulkano/src/tests.rs
@@ -56,7 +56,7 @@ macro_rules! gfx_dev_and_queue {
         }
 
         let (device, mut queues) = match Device::new(&physical, &features,
-                                                     &extensions, None, [(queue, 0.5)].iter().cloned())
+                                                     &extensions, [(queue, 0.5)].iter().cloned())
         {
             Ok(r) => r,
             Err(_) => return


### PR DESCRIPTION
Device layers are deprecated starting in Vulkan 1.0.13. The specification recommends that we pass the instance layer names to the device creation functions as well. This assures backwards compatibility because there are no known device-only layers pre-1.0.13, and post-1.0.13 those arguments are ignored (except by validation layers).