### PR TITLE
Window creation: Add support for wayland on unixes

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ vulkano = { path = "../vulkano" }
 vulkano-win = { path = "../vulkano-win" }
 cgmath = "0.7.0"
 image = "0.6.1"
-winit = { git = "https://github.com/tomaka/winit"  }
+winit = "0.5.1"
 
 [build-dependencies]
 vk-sys = { path = "../vk-sys" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ vulkano = { path = "../vulkano" }
 vulkano-win = { path = "../vulkano-win" }
 cgmath = "0.7.0"
 image = "0.6.1"
-winit = "0.5.0"
+winit = { git = "https://github.com/tomaka/winit"  }
 
 [build-dependencies]
 vk-sys = { path = "../vk-sys" }

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 vulkano = { version = "0.1.0", path = "../vulkano" }
-winit = { git = "https://github.com/tomaka/winit"  }
+winit = "0.5.1"

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 vulkano = { version = "0.1.0", path = "../vulkano" }
-winit = "0.5.0"
+winit = { git = "https://github.com/tomaka/winit"  }


### PR DESCRIPTION
On unix, we try to get the `wayland_display` and `wayland_surface`. If this fails, we fall back to X11.

There's also some rustfmt formatting contained here, hope it doesn't bother you too much :/

Since the winit version which exposes the wayland functions has not been publieshed yet, we depend on the git version of winit. You could also publish winit before merging and I will change the `Cargo.toml` files to depend on 0.5.1.