### PR TITLE
Fix device leaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vulkano
 
-**Note: requires Rust 1.8**. This library would highly benefit from multiple upcoming features in
+**Note: requires Rust 1.9**. This library would highly benefit from multiple upcoming features in
 Rust. Therefore it is likely that in the future you will need to update your version of Rust to
 continue using vulkano.
 

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -138,7 +138,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                            .filter(|t| t.is_host_visible())
                            .next().unwrap();    // Vk specs guarantee that this can't fail
 
-        let mem = try!(MemoryPool::alloc(&device.standard_pool(), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Linear));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         debug_assert!(mem.mapped_memory().is_some());

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -130,7 +130,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&device.standard_pool(), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Linear));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         try!(buffer.bind_memory(mem.memory(), mem.offset()));

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -128,7 +128,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&device.standard_pool(), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Linear));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         try!(buffer.bind_memory(mem.memory(), mem.offset()));

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -165,7 +165,7 @@ impl<F> AttachmentImage<F> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&device.standard_pool(), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Optimal));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe { try!(image.bind_memory(mem.memory(), mem.offset())); }

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -91,7 +91,7 @@ impl<F> ImmutableImage<F> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&device.standard_pool(), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Optimal));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe { try!(image.bind_memory(mem.memory(), mem.offset())); }

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -63,12 +63,12 @@ unsafe impl MemoryPool for StdMemoryPool {
                     &Pool::HostVisible(ref pool) => {
                         let alloc = try!(StdHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::HostVisible(alloc);
-                        Ok(StdMemoryPoolAlloc { inner: inner })
+                        Ok(StdMemoryPoolAlloc { inner: inner, pool: me.clone() })
                     },
                     &Pool::NonHostVisible(ref pool) => {
                         let alloc = try!(StdNonHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::NonHostVisible(alloc);
-                        Ok(StdMemoryPoolAlloc { inner: inner })
+                        Ok(StdMemoryPoolAlloc { inner: inner, pool: me.clone() })
                     },
                 }
             },
@@ -80,14 +80,14 @@ unsafe impl MemoryPool for StdMemoryPool {
                         entry.insert(Pool::HostVisible(pool.clone()));
                         let alloc = try!(StdHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::HostVisible(alloc);
-                        Ok(StdMemoryPoolAlloc { inner: inner })
+                        Ok(StdMemoryPoolAlloc { inner: inner, pool: me.clone() })
                     },
                     false => {
                         let pool = StdNonHostVisibleMemoryTypePool::new(&me.device, memory_type);
                         entry.insert(Pool::NonHostVisible(pool.clone()));
                         let alloc = try!(StdNonHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::NonHostVisible(alloc);
-                        Ok(StdMemoryPoolAlloc { inner: inner })
+                        Ok(StdMemoryPoolAlloc { inner: inner, pool: me.clone() })
                     },
                 }
             },
@@ -103,7 +103,8 @@ enum Pool {
 
 #[derive(Debug)]
 pub struct StdMemoryPoolAlloc {
-    inner: StdMemoryPoolAllocInner
+    inner: StdMemoryPoolAllocInner,
+    pool: Arc<StdMemoryPool>,
 }
 
 impl StdMemoryPoolAlloc {


### PR DESCRIPTION
`Device` wouldn't get destroyed because it held the pool.

This is also a breaking change as vulkano now requires Rust 1.9 (future PRs will use things from this version as well).
