### PR TITLE
Added StorageImage as a new descriptor for the pipeline_layout macro.

### DIFF
--- a/vulkano/src/descriptor/pipeline_layout/custom_pipeline_macro.rs
+++ b/vulkano/src/descriptor/pipeline_layout/custom_pipeline_macro.rs
@@ -130,6 +130,7 @@ macro_rules! pipeline_layout {
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::SampledImage;
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::DescriptorMarker;
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::StorageBuffer;
+            use $crate::descriptor::pipeline_layout::custom_pipeline_macro::StorageImage;
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::UniformBuffer;
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::InputAttachment;
             use $crate::descriptor::pipeline_layout::custom_pipeline_macro::ValidParameter;
@@ -339,6 +340,30 @@ unsafe impl<'a, I> ValidParameter<SampledImage> for &'a Arc<I>
     #[inline]
     fn write(&self, binding: u32) -> DescriptorWrite {
         DescriptorWrite::sampled_image(binding, self)
+    }
+}
+
+pub struct StorageImage;
+unsafe impl DescriptorMarker for StorageImage {
+    #[inline]
+    fn descriptor_type() -> DescriptorDescTy {
+        DescriptorDescTy::Image(DescriptorImageDesc {
+            sampled: false,
+            // FIXME: correct values
+            dimensions: DescriptorImageDescDimensions::TwoDimensional,
+            multisampled: false,
+            array_layers: DescriptorImageDescArray::NonArrayed,
+            format: None,
+        })
+    }
+}
+
+unsafe impl<'a, I> ValidParameter<StorageImage> for &'a Arc<I>
+    where I: ImageView + 'static
+{
+    #[inline]
+    fn write(&self, binding: u32) -> DescriptorWrite {
+        DescriptorWrite::storage_image(binding, self)
     }
 }
 


### PR DESCRIPTION
Thanks - This approach will work for me. It would be nice to be able to pass in a struct of defaults I want to set for DescriptorImageDesc and make use of the Rust .. syntax to add in ::empy() values I don't care about, but I now sure how to cleanly add that here yet.