### PR TITLE
Added debugging example code

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[macro_use]
+extern crate vulkano;
+
+use vulkano::device::{Device, DeviceExtensions};
+use vulkano::format::Format;
+use vulkano::image::ImmutableImage;
+use vulkano::image::sys::Dimensions;
+use vulkano::instance;
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::debug::{DebugCallback, MessageTypes};
+
+fn main() {
+    // Vulkano Debugging Example Code
+    //
+    // This example code will demonstrate using the debug functions of the Vulkano api.
+    //
+    // There is documentation here about how to setup debugging:
+    // https://vulkan.lunarg.com/doc/view/1.0.13.0/windows/layers.html
+    //
+    // .. but if you just want a template of code that has everything ready to go then follow
+    // this example. First, enable debugging using this extension: VK_EXT_debug_report
+    let extensions = InstanceExtensions {
+        ext_debug_report: true,
+        ..InstanceExtensions::none()
+    };
+
+    // You also need to specify (unless you've used the methods linked above) which debugging layers
+    // your code should use. Each layer is a bunch of checks or messages that provide information of
+    // some sort.
+    //
+    // The main layer you might want is: VK_LAYER_LUNARG_standard_validation
+    // This includes a number of the other layers for you and is quite detailed.
+    //
+    // Additional layers can be installed (gpu vendor provided, something you found on github, etc)
+    // and you should verify that list for safety - Volkano will return an error if you specify
+    // any layers that are not installed on this system. That code to do could look like this:
+    println!("List of Vulkan debugging layers available to use:");
+    let mut layers = instance::layers_list().unwrap();
+    while let Some(l) = layers.next() {
+        println!("\t{}", l.name());
+    }
+
+    // NOTE: To simplify the example code we won't verify these layer(s) are actually in the layers list:
+    let layer = "VK_LAYER_LUNARG_standard_validation";
+    let layers = vec![&layer];
+
+    // Important: pass the extension(s) and layer(s) when creating the vulkano instance
+    let instance = Instance::new(None, &extensions, layers).expect("failed to create Vulkan instance");
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // After creating the instance we must register the debugging callback.                                      //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Note: If you let this debug_callback binding fall out of scope then the callback will stop providing events
+    let debug_callback = DebugCallback::new(&instance, MessageTypes::all(), |msg| {
+        println!("{} {}: {}", msg.layer_prefix, msg.ty, msg.description);
+    }).ok();
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Create vulkan objects in the same way as the other examples                                               //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    let physical = PhysicalDevice::enumerate(&instance).next().expect("no device available");
+    let queue = physical.queue_families().next().expect("couldn't find a queue family");
+    let (device, mut queues) = Device::new(&physical, physical.supported_features(), &DeviceExtensions::none(), vec![(queue, 0.5)]).expect("failed to create device");
+    let queue = queues.next().unwrap();
+
+    // Create an image in order to generate some additional logging:
+    let pixel_format = Format::R8G8B8A8Uint;
+    let dimensions = Dimensions::Dim2d { width: 4096, height: 4096 };
+    ImmutableImage::new(&device, dimensions, pixel_format, Some(queue.family())).unwrap();
+
+    // (At this point you should see a bunch of messages printed to the terminal window - have fun debugging!)
+}

--- a/vulkano/src/command_buffer/inner.rs
+++ b/vulkano/src/command_buffer/inner.rs
@@ -89,7 +89,7 @@ pub struct InnerCommandBufferBuilder<P> where P: CommandPool {
     // If true, we're inside a secondary graphics command buffer.
     is_secondary_graphics: bool,
 
-    // List of accesses made by this command buffer to buffers and images, exclusing the staging
+    // List of accesses made by this command buffer to buffers and images, excluding the staging
     // commands and the staging render pass.
     //
     // If a buffer/image is missing in this list, that means it hasn't been used by this command
@@ -1370,7 +1370,7 @@ impl<P> InnerCommandBufferBuilder<P> where P: CommandPool {
             self.flush(false);
         }
 
-        // Now merging the render pass accesses with the outter accesses.
+        // Now merging the render pass accesses with the outer accesses.
         // Conflicts shouldn't happen since we checked above, but they are partly checked again
         // with `debug_assert`s.
         for ((buffer, block), access) in self.render_pass_staging_required_buffer_accesses.drain() {

--- a/vulkano/src/command_buffer/inner.rs
+++ b/vulkano/src/command_buffer/inner.rs
@@ -1449,8 +1449,8 @@ impl<P> InnerCommandBufferBuilder<P> where P: CommandPool {
                             srcQueueFamilyIndex: vk::QUEUE_FAMILY_IGNORED,
                             dstQueueFamilyIndex: vk::QUEUE_FAMILY_IGNORED,
                             buffer: (buffer.0).0.inner_buffer().internal_object(),
-                            offset: range.start as u64,
-                            size: (range.end - range.start) as u64,
+                            offset: 0,
+                            size: vk::WHOLE_SIZE,
                         });
                     }
 
@@ -1475,8 +1475,8 @@ impl<P> InnerCommandBufferBuilder<P> where P: CommandPool {
                             srcQueueFamilyIndex: vk::QUEUE_FAMILY_IGNORED,
                             dstQueueFamilyIndex: vk::QUEUE_FAMILY_IGNORED,
                             buffer: (buffer.0).0.inner_buffer().internal_object(),
-                            offset: range.start as u64,
-                            size: (range.end - range.start) as u64,
+                            offset: 0,
+                            size: vk::WHOLE_SIZE,
                         });
 
                         entry.stages = access.stages;

--- a/vulkano/src/command_buffer/outer.rs
+++ b/vulkano/src/command_buffer/outer.rs
@@ -51,7 +51,7 @@ use OomError;
 ///
 /// ```ignore   // TODO: change that
 /// let commands_buffer =
-///     PrimaryCommandBufferBuilder::new(&device)
+///     PrimaryCommandBufferBuilder::new(&device, queue.family())
 ///         .copy_memory(..., ...)
 ///         .draw(...)
 ///         .build();

--- a/vulkano/src/descriptor/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor/descriptor_set/pool.rs
@@ -48,6 +48,10 @@ impl DescriptorPool {
                 descriptorCount: 10,
             },
             vk::DescriptorPoolSize {
+                ty: vk::DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                descriptorCount: 10,
+            },
+            vk::DescriptorPoolSize {
                 ty: vk::DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                 descriptorCount: 10,
             },

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -191,6 +191,18 @@ pub struct MessageTypes {
 }
 
 impl MessageTypes {
+    /// Builds a `MessageTypes` with all fields set to `true`.
+    #[inline]
+    pub fn all() -> MessageTypes {
+        MessageTypes {
+            error: true,
+            warning: true,
+            performance_warning: true,
+            information: true,
+            debug: true,
+        }
+    }
+
     /// Builds a `MessageTypes` with all fields set to `false` expect `error`.
     #[inline]
     pub fn errors() -> MessageTypes {
@@ -253,5 +265,24 @@ impl From<Error> for DebugCallbackCreationError {
     #[inline]
     fn from(err: Error) -> DebugCallbackCreationError {
         panic!("unexpected error: {:?}", err)
+    }
+}
+
+impl fmt::Display for MessageTypes {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        if self.error {
+            write!(fmt, "error")
+        } else if self.warning {
+            write!(fmt, "warning")
+        } else if self.performance_warning {
+            write!(fmt, "performance_warning")
+        } else if self.information {
+            write!(fmt, "information")
+        } else if self.debug {
+            write!(fmt, "debug")
+        } else {
+            write!(fmt, "{:?}", self)
+        }
     }
 }

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -62,7 +62,7 @@ impl<Pl> ComputePipeline<Pl> {
             };
 
             let stage = vk::PipelineShaderStageCreateInfo {
-                sType: vk::STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+                sType: vk::STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
                 pNext: ptr::null(),
                 flags: 0,
                 stage: vk::SHADER_STAGE_COMPUTE_BIT,


### PR DESCRIPTION
I'm still having trouble with your new storage image implementation (thank you!) so I've decided to get better at debugging Vulkan. The steps to get this going, while simple, took a few stabs to get correct and so I've put together a small example for others to follow.

I also added some helper and formatter code to to the instance/debug module.