### PR TITLE
[RFC] Draft for StdCommandBufferBuilder

### DIFF
--- a/vulkano/src/command_buffer/standard/mod.rs
+++ b/vulkano/src/command_buffer/standard/mod.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! Standard implementation of the `CommandBuffer` trait.
+//! 
+//! Everything in this module is dedicated to the "standard" implementation of command buffers.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use buffer::Buffer;
+use buffer::BufferSlice;
+use command_buffer::CommandBuffer;
+use command_buffer::pool::CommandPool;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use image::Image;
+use image::sys::Layout;
+use sync::AccessFlagBits;
+use sync::PipelineStages;
+
+use self::update_buffer::StdUpdateBufferBuilder;
+
+pub mod primary;
+pub mod update_buffer;
+
+mod sync_helper;
+
+///
+pub unsafe trait StdCommandBufferBuilder {
+    /// The finished command buffer.
+    type BuildOutput: CommandBuffer;
+
+    /// The command pool that was used to build the command buffer.
+    type Pool: CommandPool;
+
+    /// Adds a buffer update command at the end of the command buffer builder.
+    #[inline]
+    fn update_buffer<'a, 'b, D, S, B: 'b>(self, buffer: S, data: &'a D)
+                                          -> StdUpdateBufferBuilder<'a, Self, D, B>
+        where Self: Sized,
+              B: Buffer,
+              S: Into<BufferSlice<'b, D, B>>,
+              D: Copy + 'static,
+    {
+        StdUpdateBufferBuilder::new(self, buffer, data)
+    }
+
+    unsafe fn add_command<F>(&mut self, cmd: F)
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<Self::Pool>);
+
+    unsafe fn add_buffer_usage<B>(&mut self, buffer: &Arc<B>, slice: Range<usize>, write: bool,
+                                  stages: PipelineStages, accesses: AccessFlagBits)
+        where B: Buffer;
+
+    unsafe fn add_image_usage<I>(&mut self, image: &Arc<I>, mipmaps: Range<u32>,
+                                 array_layers: Range<u32>, write: bool, layout: Layout,
+                                 stages: PipelineStages, accesses: AccessFlagBits)
+        where I: Image;
+
+    /// Returns true if the parameter is the same pipeline as the one that is currently binded on
+    /// the graphics slot.
+    ///
+    /// Since this is purely an optimization to avoid having to bind the pipeline again, you can
+    /// return `false` when in doubt.
+    ///
+    /// This function doesn't take into account any possible command that you add through
+    /// `add_command`.
+    #[inline]
+    fn is_current_graphics_pipeline(&self /*, pipeline: &P */) -> bool {
+        false
+    }
+
+    /// Finishes building the command buffer.
+    ///
+    /// Consumes the builder and returns an implementation of `StdCommandBuffer`.
+    fn build(self) -> Self::BuildOutput;
+}

--- a/vulkano/src/command_buffer/standard/primary.rs
+++ b/vulkano/src/command_buffer/standard/primary.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use buffer::Buffer;
+use command_buffer::CommandBuffer;
+use command_buffer::pool::CommandPool;
+use command_buffer::pool::StandardCommandPool;
+use command_buffer::standard::StdCommandBufferBuilder;
+use command_buffer::standard::sync_helper::BuilderSyncHelper;
+use command_buffer::sys::Flags;
+use command_buffer::sys::Kind;
+use command_buffer::sys::UnsafeCommandBuffer;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use framebuffer::EmptySinglePassRenderPass;
+use image::Image;
+use image::sys::Layout;
+use sync::PipelineStages;
+use sync::AccessFlagBits;
+
+/// An empty primary command buffer builder.
+pub struct StdPrimaryCommandBufferBuilder<P = Arc<StandardCommandPool>> where P: CommandPool {
+    inner: UnsafeCommandBufferBuilder<P>,
+    sync_helper: BuilderSyncHelper,
+}
+
+impl<P> StdPrimaryCommandBufferBuilder<P> where P: CommandPool {
+    /// Builds a new empty primary command buffer.
+    #[inline]
+    pub fn new(pool: P) -> StdPrimaryCommandBufferBuilder<P> {
+        let kind = Kind::Primary::<EmptySinglePassRenderPass, EmptySinglePassRenderPass>;
+        let cb = UnsafeCommandBufferBuilder::new(pool, kind, Flags::SimultaneousUse).unwrap();  // TODO: allow handling this error
+
+        StdPrimaryCommandBufferBuilder {
+            inner: cb,
+        }
+    }
+}
+
+unsafe impl<P> StdCommandBufferBuilder for StdPrimaryCommandBufferBuilder<P>
+    where P: CommandPool
+{
+    type BuildOutput = StdPrimaryCommandBuffer<P>;
+    type Pool = P;
+
+    #[inline]
+    unsafe fn add_command<F>(&mut self, cmd: F)
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<P>)
+    {
+        cmd(&mut self.inner)
+    }
+
+    #[inline]
+    unsafe fn add_buffer_usage<B>(&mut self, buffer: &Arc<B>, slice: Range<usize>, write: bool,
+                                  stages: PipelineStages, accesses: AccessFlagBits)
+        where B: Buffer
+    {
+        unimplemented!()
+    }
+
+    #[inline]
+    unsafe fn add_image_usage<I>(&mut self, image: &Arc<I>, mipmaps: Range<u32>,
+                                 array_layers: Range<u32>, write: bool, layout: Layout,
+                                 stages: PipelineStages, accesses: AccessFlagBits)
+        where I: Image
+    {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn build(self) -> StdPrimaryCommandBuffer<P> {
+        StdPrimaryCommandBuffer {
+            inner: self.inner.build().unwrap(),     // TODO: allow handling this error
+        }
+    }
+}
+
+/// An empty primary command buffer.
+pub struct StdPrimaryCommandBuffer<P = Arc<StandardCommandPool>> where P: CommandPool {
+    inner: UnsafeCommandBuffer<P>
+}
+
+unsafe impl<P> CommandBuffer for StdPrimaryCommandBuffer<P> where P: CommandPool {
+    type Pool = P;
+
+    #[inline]
+    fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
+        &self.inner
+    }
+
+    #[inline]
+    fn set_one_time_submit_flag(&self) -> Result<(), ()> {
+        // FIXME:
+        Ok(())
+    }
+}

--- a/vulkano/src/command_buffer/standard/sync_helper.rs
+++ b/vulkano/src/command_buffer/standard/sync_helper.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! Helps choosing the pipeline barriers that are required when building or submitting a command
+//! buffer.
+
+// Note that everything here is unstable, as the current "blocks" system may be reworked.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::fmt;
+use std::hash;
+use std::hash::BuildHasherDefault;
+use std::mem;
+use std::ops::Range;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::u64;
+use fnv::FnvHasher;
+use smallvec::SmallVec;
+
+use command_buffer::DrawIndirectCommand;
+use command_buffer::DynamicState;
+use command_buffer::pool::CommandPool;
+use command_buffer::pool::CommandPoolFinished;
+use command_buffer::pool::StandardCommandPool;
+use descriptor::descriptor_set::DescriptorSetsCollection;
+
+/// Helps building the pipeline barriers while constructing a command buffer.
+pub struct BuilderSyncHelper {
+    // List of accesses made by this command buffer to buffers and images, exclusing the staging
+    // commands and the staging render pass.
+    //
+    // If a buffer/image is missing in this list, that means it hasn't been used by this command
+    // buffer yet and is still in its default state.
+    //
+    // This list is only updated by the `flush()` function.
+    buffers_state: HashMap<(vk::Buffer, usize), InternalBufferBlockAccess,
+                           BuildHasherDefault<FnvHasher>>,
+    images_state: HashMap<(vk::Image, (u32, u32)), InternalImageBlockAccess,
+                          BuildHasherDefault<FnvHasher>>,
+
+    // List of commands that are waiting to be submitted to the Vulkan command buffer. Doesn't
+    // include commands that were submitted within a render pass.
+    staging_commands: Vec<Box<FnMut(&vk::DevicePointers, vk::CommandBuffer) + Send + Sync>>,
+
+    // List of resources accesses made by the comands in `staging_commands`. Doesn't include
+    // commands added to the current render pass.
+    staging_required_buffer_accesses: HashMap<(vk::Buffer, usize), InternalBufferBlockAccess,
+                                              BuildHasherDefault<FnvHasher>>,
+    staging_required_image_accesses: HashMap<(vk::Image, (u32, u32)), InternalImageBlockAccess,
+                                             BuildHasherDefault<FnvHasher>>,
+
+    // List of commands that are waiting to be submitted to the Vulkan command buffer when we're
+    // inside a render pass. Flushed when `end_renderpass` is called.
+    render_pass_staging_commands: Vec<Box<FnMut(&vk::DevicePointers, vk::CommandBuffer) +
+                                          Send + Sync>>,
+
+    // List of resources accesses made by the current render pass. Merged with
+    // `staging_required_buffer_accesses` and `staging_required_image_accesses` when
+    // `end_renderpass` is called.
+    render_pass_staging_required_buffer_accesses: HashMap<(vk::Buffer, usize),
+                                                          InternalBufferBlockAccess,
+                                                          BuildHasherDefault<FnvHasher>>,
+    render_pass_staging_required_image_accesses: HashMap<(vk::Image, (u32, u32)),
+                                                         InternalImageBlockAccess,
+                                                         BuildHasherDefault<FnvHasher>>,
+}
+
+impl BuilderSyncHelper {
+    #[inline]
+    pub fn new() -> BuilderSyncHelper {
+        buffers_state: HashMap::new(),
+        images_state: HashMap::new(),
+        staging_commands: Vec::new(),
+        staging_required_buffer_accesses: HashMap::new(),
+        staging_required_image_accesses: HashMap::new(),
+        render_pass_staging_commands: Vec::new(),
+        render_pass_staging_required_buffer_accesses: HashMap::new(),
+        render_pass_staging_required_image_accesses: HashMap::new(),
+    }
+}

--- a/vulkano/src/command_buffer/standard/update_buffer.rs
+++ b/vulkano/src/command_buffer/standard/update_buffer.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::mem;
+use std::ops::Range;
+use std::sync::Arc;
+
+use buffer::Buffer;
+use buffer::BufferSlice;
+use command_buffer::CommandBuffer;
+use command_buffer::standard::StdCommandBufferBuilder;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use command_buffer::sys::UnsafeCommandBuffer;
+use image::Image;
+use image::sys::Layout;
+use sync::AccessFlagBits;
+use sync::PipelineStages;
+
+/// Wrapper around a `StdCommandBufferBuilder` that adds a buffer updating command at the end of
+/// the builder.
+pub struct StdUpdateBufferBuilder<'a, T, D: 'a, B> {
+    inner: T,
+    data: &'a D,
+    buffer: Arc<B>,
+}
+
+impl<'a, T, D, B> StdUpdateBufferBuilder<'a, T, D, B> where T: StdCommandBufferBuilder {
+    /// Adds the command at the end of `inner`.
+    pub fn new<'b, S>(mut inner: T, buffer: S, data: &'a D) -> StdUpdateBufferBuilder<'a, T, D, B>
+        where S: Into<BufferSlice<'b, D, B>>,
+              B: Buffer + 'b,
+              D: Copy + 'static,
+    {
+        let buffer = buffer.into();
+
+        // FIXME: check outsideness of render pass
+
+        // TODO: return error instead
+        assert_eq!(buffer.offset() % 4, 0);
+        assert_eq!(buffer.size() % 4, 0);
+        assert!(mem::size_of_val(data) <= 65536);
+        assert!(buffer.buffer().inner().usage_transfer_dest());
+
+        let keep_alive = buffer.buffer().clone();
+
+        let stage = PipelineStages {
+            transfer: true,
+            .. PipelineStages::none()
+        };
+
+        let access = AccessFlagBits {
+            transfer_write: true,
+            .. AccessFlagBits::none()
+        };
+
+        unsafe {
+            inner.add_buffer_usage(&buffer.buffer(),
+                                   buffer.offset() .. (buffer.offset() + buffer.size()),
+                                   true, stage, access);
+
+            inner.add_command(move |cb| cb.update_buffer(buffer.buffer().inner(), buffer.offset(),
+                                                         buffer.size(), data));
+        }
+
+        StdUpdateBufferBuilder {
+            inner: inner,
+            data: data,
+            buffer: keep_alive,
+        }
+    }
+}
+
+unsafe impl<'a, T, D: 'a, B> StdCommandBufferBuilder for StdUpdateBufferBuilder<'a, T, D, B>
+    where T: StdCommandBufferBuilder,
+          B: Buffer
+{
+    type BuildOutput = StdUpdateBuffer<T::BuildOutput, B>;
+    type Pool = T::Pool;
+
+    #[inline]
+    unsafe fn add_command<F>(&mut self, cmd: F)
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<Self::Pool>)
+    {
+        self.inner.add_command(cmd)
+    }
+
+    #[inline]
+    unsafe fn add_buffer_usage<X>(&mut self, buffer: &Arc<X>, slice: Range<usize>, write: bool,
+                                  stages: PipelineStages, accesses: AccessFlagBits)
+        where X: Buffer
+    {
+        self.inner.add_buffer_usage(buffer, slice, write, stages, accesses)
+    }
+
+    #[inline]
+    unsafe fn add_image_usage<I>(&mut self, image: &Arc<I>, mipmaps: Range<u32>,
+                                 array_layers: Range<u32>, write: bool, layout: Layout,
+                                 stages: PipelineStages, accesses: AccessFlagBits)
+        where I: Image
+    {
+        self.inner.add_image_usage(image, mipmaps, array_layers, write, layout, stages, accesses)
+    }
+
+    #[inline]
+    fn build(self) -> Self::BuildOutput {
+        StdUpdateBuffer {
+            inner: self.inner.build(),
+            buffer: self.buffer,
+        }
+    }
+}
+
+/// Wrapper around a command buffer that keeps the buffer alive.
+pub struct StdUpdateBuffer<T, B> {
+    inner: T,
+    buffer: Arc<B>,
+}
+
+unsafe impl<T, B> CommandBuffer for StdUpdateBuffer<T, B> where T: CommandBuffer {
+    type Pool = T::Pool;
+
+    #[inline]
+    fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
+        self.inner.inner()
+    }
+
+    #[inline]
+    fn set_one_time_submit_flag(&self) -> Result<(), ()> {
+        self.inner.set_one_time_submit_flag()
+    }
+}

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1279,6 +1279,7 @@ pub struct UnsafeCommandBuffer<P> where P: CommandPool {
 
     // True if the command buffer has always been submitted once. Only relevant if `flags` is
     // `OneTimeSubmit`.
+    // TODO: don't put that here?
     already_submitted: AtomicBool,
 
     // True if we are a secondary command buffer.


### PR DESCRIPTION
Here's the draft for the new design for command buffers.

Instead of using an opaque giant structure with several vecs and hashmaps like it is currently the case, the idea here is to have an iterator-like system where each command adds a wrapper around the previous ones.

For example you start with `StdPrimaryCommandBufferBuilder::new(...)`, which gives you a `StdPrimaryCommandBufferBuilder`. You then call `update_buffer()` on it (through the `StdCommandBufferBuilder` trait that is similar to `Iterator`), which will yield you a `StdUpdateBufferBuilder<StdPrimaryCommandBufferBuilder, ...>` (the second template parameter being the type of data). You then call `build()` to finish the construction, and it will yield you a `StdUpdateBuffer<StdPrimaryCommandBuffer, ...>`.

Of course these types are not supposed to be expressed directly. The idea is that a if you want to express the type of a command buffer builder or a command buffer, you should use a `Box<Trait>` or an `Arc<Trait>` like you would do with an iterator today. Maybe in the future Rust will provide a syntax to make this easier. Since iterators and closures have the same problem, it is likely to happen.

This new approach has several advantages:

- No allocation. Right now a command buffer builder has several Vecs and HashMaps. In the new design, all their contents will be put in regular struct members instead.
- It will be possible to use something else than `Arc`s to keep objects alive. For example in the future you should be able to pass a simple reference to a buffer to a command buffer instead of an `Arc<Buffer>`.
- Less indirections. Since everything is a regular struct member and trait objects will no longer be used, this means that more inlining and more optimizations are possible by the compiler.
- No more distinction between `PrimaryCommandBufferBuilder`, `SecondaryGraphics...` and `SecondaryCompute...`. Instead it will be done through traits.
- The "update buffer" command no longer needs to do an additional copy of the data.

The drawbacks are:

- The commands are effectively added only when you call `build`. This means that adding commands will take very few time (only validations are performed), but calling `build` will take a long time. I don't think it's that much of a problem though, as the total time remains the same.
- The `StdPrimaryCommandBufferBuilder` trait will need to be imported by the user in order to add commands.
