### PR TITLE
Change vulkan library name on unix

### DIFF
--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -19,7 +19,7 @@ use vk;
 lazy_static! {
     static ref VK_LIB: Result<shared_library::dynamic_library::DynamicLibrary, LoadingError> = {
         #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
+        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
         let path = get_path();
         shared_library::dynamic_library::DynamicLibrary::open(Some(path))
                                     .map_err(|err| LoadingError::LibraryLoadFailure(err))

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -19,7 +19,8 @@ use vk;
 lazy_static! {
     static ref VK_LIB: Result<shared_library::dynamic_library::DynamicLibrary, LoadingError> = {
         #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-        #[cfg(unix)] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
+        #[cfg(all(unix, not(target_os = "android")))] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
+        #[cfg(target_os = "android")] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
         let path = get_path();
         shared_library::dynamic_library::DynamicLibrary::open(Some(path))
                                     .map_err(|err| LoadingError::LibraryLoadFailure(err))


### PR DESCRIPTION
libvulkan.so does not exist in ubuntu or steam for linux. There is
however a libvulkan.so.1 . Using this vulkano works on a default install.

see #163 