### PR TITLE
New command buffers system

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -348,6 +348,15 @@ impl Usage {
         }
     }
 
+    /// Builds a `Usage` with `transfer_dest` set to true and the rest to false.
+    #[inline]
+    pub fn transfer_dest() -> Usage {
+        Usage {
+            transfer_dest: true,
+            .. Usage::none()
+        }
+    }
+
     /// Builds a `Usage` with `vertex_buffer` set to true and the rest to false.
     #[inline]
     pub fn vertex_buffer() -> Usage {

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -7,13 +7,23 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::any::Any;
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
 
 use buffer::sys::UnsafeBuffer;
 use command_buffer::Submission;
+use device::Queue;
 use memory::Content;
+
+use sync::AccessFlagBits;
+use sync::Fence;
+use sync::PipelineStages;
 use sync::Semaphore;
+
+use VulkanObject;
 
 pub unsafe trait Buffer: 'static + Send + Sync {
     /// Returns the inner buffer.
@@ -55,6 +65,147 @@ pub unsafe trait Buffer: 'static + Send + Sync {
     #[inline]
     fn size(&self) -> usize {
         self.inner().size()
+    }
+}
+
+/// Extension trait for `Buffer`. Types that implement this can used in a `StdCommandBuffer`.
+///
+/// Each buffer and image used in a `StdCommandBuffer` have an associated state which is
+/// represented by the `CommandListState` associated type of this trait. You can make multiple
+/// buffers or images share the same state by making `is_same` return true.
+pub unsafe trait TrackedBuffer: Buffer {
+    /// State of the buffer in a list of commands.
+    ///
+    /// The `Any` bound is here for stupid reasons, sorry.
+    // TODO: remove Any bound
+    type CommandListState: Any + CommandListState<FinishedState = Self::FinishedState>;
+    /// State of the buffer in a finished list of commands.
+    type FinishedState: CommandBufferState;
+
+    /// Returns true if TODO.
+    ///
+    /// If `is_same` returns true, then the type of `CommandListState` must be the same as for the
+    /// other buffer. Otherwise a panic will occur.
+    #[inline]
+    fn is_same<B>(&self, other: &B) -> bool where B: Buffer {
+        self.inner().internal_object() == other.inner().internal_object()
+    }
+
+    /// Returns the state of the buffer when it has not yet been used.
+    fn initial_state(&self) -> Self::CommandListState;
+}
+
+/// Trait for objects that represent the state of a slice of the buffer in a list of commands.
+pub trait CommandListState {
+    type FinishedState: CommandBufferState;
+
+    /// Returns a new state that corresponds to the moment after a slice of the buffer has been
+    /// used in the pipeline. The parameters indicate in which way it has been used.
+    ///
+    /// If the transition should result in a pipeline barrier, then it must be returned by this
+    /// function.
+    fn transition(self, num_command: usize, buffer: &UnsafeBuffer, offset: usize, size: usize,
+                  write: bool, stage: PipelineStages, access: AccessFlagBits)
+                  -> (Self, Option<PipelineBarrierRequest>)
+        where Self: Sized;
+
+    /// Function called when the command buffer builder is turned into a real command buffer.
+    ///
+    /// This function can return an additional pipeline barrier that will be applied at the end
+    /// of the command buffer.
+    fn finish(self) -> (Self::FinishedState, Option<PipelineBarrierRequest>);
+}
+
+/// Requests that a pipeline barrier is created.
+pub struct PipelineBarrierRequest {
+    /// The number of the command after which the barrier should be placed. Must usually match
+    /// the number that was passed to the previous call to `transition`, or 0 if the buffer hasn't
+    /// been used yet.
+    pub after_command_num: usize,
+
+    /// The source pipeline stages of the transition.
+    pub source_stage: PipelineStages,
+
+    /// The destination pipeline stages of the transition.
+    pub destination_stages: PipelineStages,
+
+    /// If true, the pipeliner barrier is by region. There is literaly no reason to pass `false`
+    /// here, but it is included just in case.
+    pub by_region: bool,
+
+    /// An optional memory barrier. See the docs of `PipelineMemoryBarrierRequest`.
+    pub memory_barrier: Option<PipelineMemoryBarrierRequest>,
+}
+
+/// Requests that a memory barrier is created as part of the pipeline barrier.
+///
+/// By default, a pipeline barrier only guarantees that the source operations are executed before
+/// the destination operations, but it doesn't make memory writes made by source operations visible
+/// to the destination operations. In order to make so, you have to add a memory barrier.
+///
+/// The memory barrier always concerns the buffer that is currently being processed. You can't add
+/// a memory barrier that concerns another resource.
+pub struct PipelineMemoryBarrierRequest {
+    /// Offset of start of the range to flush.
+    pub offset: usize,
+    /// Size of the range to flush.
+    pub size: usize,
+    /// Source accesses.
+    pub source_access: AccessFlagBits,
+    /// Destination accesses.
+    pub destination_access: AccessFlagBits,
+}
+
+/// Trait for objects that represent the state of a slice of the buffer in a command buffer.
+pub trait CommandBufferState {
+    /// Called right before the command buffer is submitted.
+    // TODO: function should be unsafe because it must be guaranteed that a cb is submitted
+    fn on_submit<B, F>(&self, buffer: &B, queue: &Arc<Queue>, fence: F) -> SubmitInfos
+        where B: Buffer, F: FnOnce() -> Arc<Fence>;
+}
+
+pub struct SubmitInfos {
+    pub pre_semaphore: Option<(Receiver<Arc<Semaphore>>, PipelineStages)>,
+    pub post_semaphore: Option<Sender<Arc<Semaphore>>>,
+    pub pre_barrier: Option<PipelineBarrierRequest>,
+    pub post_barrier: Option<PipelineBarrierRequest>,
+}
+
+unsafe impl<B> Buffer for Arc<B> where B: Buffer {
+    #[inline]
+    fn inner(&self) -> &UnsafeBuffer {
+        (**self).inner()
+    }
+
+    fn needs_fence(&self, _: bool, _: Range<usize>) -> Option<bool> { unimplemented!() }
+
+    fn host_accesses(&self, _: usize) -> bool { unimplemented!() }
+
+    fn blocks(&self, _: Range<usize>) -> Vec<usize> { unimplemented!() }
+
+    fn block_memory_range(&self, _: usize) -> Range<usize> { unimplemented!() }
+
+    unsafe fn gpu_access(&self, _: &mut Iterator<Item = AccessRange>,
+                         _: &Arc<Submission>) -> GpuAccessResult { unimplemented!() }
+
+    #[inline]
+    fn size(&self) -> usize {
+        (**self).size()
+    }
+}
+
+unsafe impl<B> TrackedBuffer for Arc<B> where B: TrackedBuffer, Arc<B>: Buffer {
+    type CommandListState = B::CommandListState;
+    type FinishedState = B::FinishedState;
+
+    #[inline]
+    fn is_same<Bo>(&self, other: &Bo) -> bool where Bo: Buffer {
+        (**self).is_same(other)
+    }
+
+    #[inline]
+    fn initial_state(&self) -> Self::CommandListState {
+        (**self).initial_state()
     }
 }
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -59,6 +59,7 @@ mod inner;
 mod outer;
 
 pub mod pool;
+pub mod std;
 pub mod submit;
 pub mod sys;
 

--- a/vulkano/src/command_buffer/std/copy_buffer.rs
+++ b/vulkano/src/command_buffer/std/copy_buffer.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::any::Any;
+
+pub struct CopyCommand<L, B> where B: Buffer, L: CommandsList {
+    previous: L,
+    buffer: B,
+    buffer_state: B::CommandBufferState,
+    transition: Option<>,
+}
+
+impl<L, B> CommandsList for CopyCommand<L, B> where B: Buffer, L: CommandsList {
+    pub fn new(previous: L, buffer: B) -> CopyCommand<L, B> {
+        let (state, transition) = previous.current_buffer_state(buffer)
+                                          .transition(false, self.num_commands(), ShaderStages, AccessFlagBits);
+        assert!(transition.after_command_num < self.num_commands());
+    }
+}
+
+unsafe impl<L, B> CommandsList for CopyCommand<L, B> where B: Buffer, L: CommandsList {
+    fn num_commands(&self) -> usize {
+        self.previous.num_commands() + 1
+    }
+
+    #[inline]
+    fn requires_graphics_queue(&self) -> bool {
+        self.previous.requires_graphics_queue()
+    }
+
+    #[inline]
+    fn requires_compute_queue(&self) -> bool {
+        self.previous.requires_compute_queue()
+    }
+
+    fn current_buffer_state<Ob>(&self, other: &Ob) -> Ob::CommandBufferState
+        where Ob: Buffer
+    {
+        if self.buffer.is_same(b) {
+            let s: &Ob::CommandBufferState = (&self.buffer_state as &Any).downcast_ref().unwrap();
+            s.clone()
+        } else {
+            self.previous.current_buffer_state(b)
+        }
+    }
+
+    unsafe fn build_unsafe_command_buffer<P, I>(&self, pool: P, transitions: I) -> UnsafeCommandBufferBuilder<P>
+        where P: CommandPool
+    {
+        let my_command_num = self.num_commands();
+
+        let mut transitions_to_apply = PipelineBarrierBuilder::new();
+
+        let transitions = transitions.filter_map(|transition| {
+            if transition.after_command_num >= my_command_num {
+                transitions_to_apply.push(transition);
+                None
+            } else {
+                Some(transition)
+            }
+        }).chain(self.transition.clone().into_iter());
+
+        let mut parent_cb = self.previous.build_unsafe_command_buffer(pool, transitions.clone().chain());
+        parent_cb.copy_buffer();
+        parent_cb.pipeline_barrier(transitions_to_apply);
+        parent_cb
+    }
+}
+
+unsafe impl StdPrimaryCommandsList

--- a/vulkano/src/command_buffer/std/empty.rs
+++ b/vulkano/src/command_buffer/std/empty.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::iter;
+use std::iter::Empty;
+use std::sync::Arc;
+
+use buffer::traits::TrackedBuffer;
+use command_buffer::pool::CommandPool;
+use command_buffer::pool::StandardCommandPool;
+use command_buffer::std::StdCommandsList;
+use command_buffer::submit::CommandBuffer;
+use command_buffer::submit::SubmitInfo;
+use command_buffer::sys::PipelineBarrierBuilder;
+use command_buffer::sys::UnsafeCommandBuffer;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use command_buffer::sys::Flags;
+use command_buffer::sys::Kind;
+use device::Device;
+use device::Queue;
+use framebuffer::EmptySinglePassRenderPass;
+use instance::QueueFamily;
+use sync::Fence;
+use sync::PipelineStages;
+use sync::Semaphore;
+
+pub struct PrimaryCbBuilder<P = Arc<StandardCommandPool>> where P: CommandPool {
+    pool: P,
+    flags: Flags,
+}
+
+impl PrimaryCbBuilder<Arc<StandardCommandPool>> {
+    /// Builds a new primary command buffer builder.
+    #[inline]
+    pub fn new(device: &Arc<Device>, family: QueueFamily)
+               -> PrimaryCbBuilder<Arc<StandardCommandPool>>
+    {
+        PrimaryCbBuilder::with_pool(Device::standard_command_pool(device, family))
+    }
+}
+
+impl<P> PrimaryCbBuilder<P> where P: CommandPool {
+    /// Builds a new primary command buffer builder that uses a specific pool.
+    pub fn with_pool(pool: P) -> PrimaryCbBuilder<P> {
+        PrimaryCbBuilder {
+            pool: pool,
+            flags: Flags::SimultaneousUse,      // TODO: allow customization
+        }
+    }
+}
+
+unsafe impl<P> StdCommandsList for PrimaryCbBuilder<P> where P: CommandPool {
+    type Pool = P;
+    type Output = PrimaryCb<P>;
+
+    #[inline]
+    fn num_commands(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn check_queue_validity(&self, queue: QueueFamily) -> Result<(), ()> {
+        Ok(())
+    }
+
+    #[inline]
+    unsafe fn extract_current_buffer_state<B>(&mut self, buffer: &B) -> Option<B::CommandListState>
+        where B: TrackedBuffer
+    {
+        None
+    }
+
+    unsafe fn raw_build<I, F>(self, additional_elements: F, transitions: I,
+                              final_transitions: PipelineBarrierBuilder) -> Self::Output
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<Self::Pool>),
+              I: Iterator<Item = (usize, PipelineBarrierBuilder)>
+    {
+        let mut pipeline_barrier = PipelineBarrierBuilder::new();
+        for (_, transition) in transitions {
+            pipeline_barrier.merge(transition);
+        }
+
+        let kind = Kind::Primary::<EmptySinglePassRenderPass, EmptySinglePassRenderPass>;
+        let mut cb = UnsafeCommandBufferBuilder::new(self.pool, kind,
+                                                     self.flags).unwrap();  // TODO: handle
+        cb.pipeline_barrier(pipeline_barrier);
+        additional_elements(&mut cb);
+        cb.pipeline_barrier(final_transitions);
+        
+        PrimaryCb {
+            cb: cb.build().unwrap(),        // TODO: handle error
+        }
+    }
+}
+
+pub struct PrimaryCb<P = Arc<StandardCommandPool>> where P: CommandPool {
+    cb: UnsafeCommandBuffer<P>,
+}
+
+unsafe impl<P> CommandBuffer for PrimaryCb<P> where P: CommandPool {
+    type Pool = P;
+    type SemaphoresWaitIterator = Empty<(Arc<Semaphore>, PipelineStages)>;
+    type SemaphoresSignalIterator = Empty<Arc<Semaphore>>;
+
+    #[inline]
+    fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
+        &self.cb
+    }
+
+    unsafe fn on_submit<F>(&self, queue: &Arc<Queue>, fence: F)
+                           -> SubmitInfo<Self::SemaphoresWaitIterator,
+                                         Self::SemaphoresSignalIterator>
+        where F: FnMut() -> Arc<Fence>
+    {
+        // TODO: must handle SimultaneousUse and Once flags
+
+        SubmitInfo {
+            semaphores_wait: iter::empty(),
+            semaphores_signal: iter::empty(),
+            pre_pipeline_barrier: PipelineBarrierBuilder::new(),
+            post_pipeline_barrier: PipelineBarrierBuilder::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use command_buffer::std::PrimaryCbBuilder;
+    use command_buffer::std::StdCommandsList;
+    use command_buffer::submit::CommandBuffer;
+
+    #[test]
+    fn basic_submit() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let _ = PrimaryCbBuilder::new(&device, queue.family()).build().submit(&queue);
+    }
+}

--- a/vulkano/src/command_buffer/std/mod.rs
+++ b/vulkano/src/command_buffer/std/mod.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::iter;
+
+use buffer::traits::TrackedBuffer;
+use command_buffer::pool::CommandPool;
+use command_buffer::submit::CommandBuffer;
+use command_buffer::sys::PipelineBarrierBuilder;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use instance::QueueFamily;
+
+pub use self::empty::PrimaryCb;
+pub use self::empty::PrimaryCbBuilder;
+pub use self::update_buffer::UpdateCommand;
+
+mod empty;
+mod update_buffer;
+
+/// A list of commands that can be turned into a command buffer.
+pub unsafe trait StdCommandsList {
+    /// The type of the pool that will be used to create the command buffer.
+    type Pool: CommandPool;
+    /// The type of the command buffer that will be generated.
+    type Output: CommandBuffer<Pool = Self::Pool>;
+
+    /// Adds a command that writes the content of a buffer.
+    ///
+    /// After this command is executed, the content of `buffer` will become `data`.
+    #[inline]
+    fn update_buffer<'a, B, D: ?Sized>(self, buffer: B, data: &'a D)
+                                       -> UpdateCommand<'a, Self, B, D>
+        where Self: Sized, B: TrackedBuffer, D: Copy + 'static
+    {
+        UpdateCommand::new(self, buffer, data)
+    }
+
+    /// Turns the commands list into a command buffer that can be submitted.
+    fn build(self) -> Self::Output where Self: Sized {
+        unsafe {
+            self.raw_build(|_| {}, iter::empty(), PipelineBarrierBuilder::new())
+        }
+    }
+
+    /// Returns the number of commands in the commands list.
+    ///
+    /// Note that multiple actual commands may count for just 1.
+    fn num_commands(&self) -> usize;
+
+    /// Checks whether the command can be executed on the given queue family.
+    // TODO: error type?
+    fn check_queue_validity(&self, queue: QueueFamily) -> Result<(), ()>;
+
+    /// Returns the current status of a buffer, or `None` if the buffer hasn't been used yet.
+    ///
+    /// Whether the buffer passed as parameter is the same as the one in the commands list must be
+    /// determined with the `is_same` method of `TrackedBuffer`.
+    ///
+    /// Calling this function tells the commands list that you are going to manage the
+    /// synchronization that buffer yourself. Hence why the function is unsafe.
+    ///
+    /// This function is not meant to be called, except when writing a wrapper around a
+    /// commands list.
+    ///
+    /// # Panic
+    ///
+    /// - Panics if the state of that buffer has already been previously extracted.
+    ///
+    unsafe fn extract_current_buffer_state<B>(&mut self, buffer: &B) -> Option<B::CommandListState>
+        where B: TrackedBuffer;
+
+    /// Turns the commands list into a command buffer.
+    ///
+    /// This function accepts additional arguments that will customize the output:
+    ///
+    /// - `additional_elements` is a closure that must be called on the command buffer builder
+    ///   after it has finished building and before `final_transitions` are added.
+    /// - `transitions` is a list of pipeline barriers accompanied by a command number. The
+    ///   pipeline barrier must happen after the given command number. Usually you want all the
+    ///   the command numbers to be inferior to `num_commands`.
+    /// - `final_transitions` is a pipeline barrier that must be added at the end of the
+    ///   command buffer builder.
+    unsafe fn raw_build<I, F>(self, additional_elements: F, transitions: I,
+                              final_transitions: PipelineBarrierBuilder) -> Self::Output
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<Self::Pool>),
+              I: Iterator<Item = (usize, PipelineBarrierBuilder)>;
+}
+
+/// Extension trait for `StdCommandsList` that indicates that we're outside a render pass.
+pub unsafe trait OutsideRenderPass: StdCommandsList {}

--- a/vulkano/src/command_buffer/std/update_buffer.rs
+++ b/vulkano/src/command_buffer/std/update_buffer.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::any::Any;
+use std::iter;
+use std::iter::Empty;
+use std::sync::Arc;
+use smallvec::SmallVec;
+
+use buffer::traits::CommandBufferState;
+use buffer::traits::CommandListState;
+use buffer::traits::PipelineBarrierRequest;
+use buffer::traits::TrackedBuffer;
+use command_buffer::std::StdCommandsList;
+use command_buffer::submit::CommandBuffer;
+use command_buffer::submit::SubmitInfo;
+use command_buffer::sys::PipelineBarrierBuilder;
+use command_buffer::sys::UnsafeCommandBuffer;
+use command_buffer::sys::UnsafeCommandBufferBuilder;
+use device::Queue;
+use instance::QueueFamily;
+use sync::AccessFlagBits;
+use sync::Fence;
+use sync::PipelineStages;
+use sync::Semaphore;
+
+pub struct UpdateCommand<'a, L, B, D: ?Sized> where B: TrackedBuffer, L: StdCommandsList, D: 'static {
+    previous: L,
+    buffer: B,
+    buffer_state: Option<B::CommandListState>,
+    data: &'a D,
+    transition: Option<PipelineBarrierRequest>,
+}
+
+impl<'a, L, B, D: ?Sized> UpdateCommand<'a, L, B, D>
+    where B: TrackedBuffer,
+          L: StdCommandsList,
+          D: Copy + 'static,
+{
+    pub fn new(mut previous: L, buffer: B, data: &'a D) -> UpdateCommand<'a, L, B, D> {
+        let stage = PipelineStages {
+            transfer: true,
+            .. PipelineStages::none()
+        };
+
+        let access = AccessFlagBits {
+            transfer_write: true,
+            .. AccessFlagBits::none()
+        };
+
+        let (state, transition) = unsafe {
+            previous.extract_current_buffer_state(&buffer)
+                    .unwrap_or(buffer.initial_state())
+                    .transition(previous.num_commands() + 1, buffer.inner(),
+                                0, buffer.size(), true, stage, access)
+        };
+
+        if let Some(ref transition) = transition {
+            assert!(transition.after_command_num <= previous.num_commands());
+        }
+
+        UpdateCommand {
+            previous: previous,
+            buffer: buffer,
+            buffer_state: Some(state),
+            data: data,
+            transition: transition,
+        }
+    }
+}
+
+unsafe impl<'a, L, B, D: ?Sized> StdCommandsList for UpdateCommand<'a, L, B, D>
+    where B: TrackedBuffer,
+          L: StdCommandsList,
+          D: Copy + 'static,
+{
+    type Pool = L::Pool;
+    type Output = UpdateCommandCb<L, B>;
+
+    #[inline]
+    fn num_commands(&self) -> usize {
+        self.previous.num_commands() + 1
+    }
+
+    #[inline]
+    fn check_queue_validity(&self, queue: QueueFamily) -> Result<(), ()> {
+        // No restriction
+        self.previous.check_queue_validity(queue)
+    }
+
+    unsafe fn extract_current_buffer_state<Ob>(&mut self, buffer: &Ob)
+                                               -> Option<Ob::CommandListState>
+        where Ob: TrackedBuffer
+    {
+        if self.buffer.is_same(buffer) {
+            let s: &mut Option<Ob::CommandListState> = (&mut self.buffer_state as &mut Any)
+                                                                        .downcast_mut().unwrap();
+            Some(s.take().unwrap())
+
+        } else {
+            self.previous.extract_current_buffer_state(buffer)
+        }
+    }
+
+    unsafe fn raw_build<I, F>(mut self, additional_elements: F, transitions: I,
+                              mut final_transitions: PipelineBarrierBuilder) -> Self::Output
+        where F: FnOnce(&mut UnsafeCommandBufferBuilder<L::Pool>),
+              I: Iterator<Item = (usize, PipelineBarrierBuilder)>
+    {
+        let finished_state = match self.buffer_state.take().map(|s| s.finish()) {
+            Some((s, t)) => {
+                if let Some(t) = t {
+                    final_transitions.add_buffer_barrier_request(self.buffer.inner(), t);
+                }
+                Some(s)
+            },
+            None => None,
+        };
+
+        // We split the transitions in two: those to apply after the actual command, and those to
+        // transfer to the parent so that they are applied before the actual command.
+
+        let my_command_num = self.num_commands();
+
+        let mut transitions_to_apply = PipelineBarrierBuilder::new();
+        let mut transitions = transitions.filter_map(|(after_command_num, transition)| {
+            if after_command_num >= my_command_num || !transitions_to_apply.is_empty() {
+                transitions_to_apply.merge(transition);
+                None
+            } else {
+                Some((after_command_num, transition))
+            }
+        }).collect::<SmallVec<[_; 8]>>();
+
+        let my_transition = if let Some(my_transition) = self.transition.take() {
+            let mut t = PipelineBarrierBuilder::new();
+            let c_num = my_transition.after_command_num;
+            t.add_buffer_barrier_request(self.buffer.inner(), my_transition);
+            Some((c_num, t))
+        } else {
+            None
+        };
+
+        let transitions = my_transition.into_iter().chain(transitions.into_iter());
+
+        let my_buffer = self.buffer;
+        let my_data = self.data;
+        let parent = self.previous.raw_build(|cb| {
+            cb.update_buffer(my_buffer.inner(), 0, my_buffer.size(), my_data);
+            cb.pipeline_barrier(transitions_to_apply);
+            additional_elements(cb);
+        }, transitions, final_transitions);
+
+        UpdateCommandCb {
+            previous: parent,
+            buffer: my_buffer,
+            buffer_state: finished_state,
+        }
+    }
+}
+
+pub struct UpdateCommandCb<L, B> where B: TrackedBuffer, L: StdCommandsList {
+    previous: L::Output,
+    buffer: B,
+    buffer_state: Option<B::FinishedState>,
+}
+
+unsafe impl<L, B> CommandBuffer for UpdateCommandCb<L, B>
+    where B: TrackedBuffer, L: StdCommandsList
+{
+    type Pool = L::Pool;
+    type SemaphoresWaitIterator = Empty<(Arc<Semaphore>, PipelineStages)>;
+    type SemaphoresSignalIterator = Empty<Arc<Semaphore>>;
+
+    #[inline]
+    fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
+        self.previous.inner()
+    }
+
+    unsafe fn on_submit<F>(&self, queue: &Arc<Queue>, mut fence: F)
+                           -> SubmitInfo<Self::SemaphoresWaitIterator,
+                                         Self::SemaphoresSignalIterator>
+        where F: FnMut() -> Arc<Fence>
+    {
+        let parent = self.previous.on_submit(queue, &mut fence);
+
+        let mut my_output = SubmitInfo {
+            semaphores_wait: iter::empty(),     // FIXME:
+            semaphores_signal: iter::empty(),     // FIXME:
+            pre_pipeline_barrier: parent.pre_pipeline_barrier,
+            post_pipeline_barrier: parent.post_pipeline_barrier,
+        };
+
+        if let Some(ref buffer_state) = self.buffer_state {
+            let submit_infos = buffer_state.on_submit(&self.buffer, queue, fence);
+
+            if let Some(pre) = submit_infos.pre_barrier {
+                my_output.pre_pipeline_barrier.add_buffer_barrier_request(self.buffer.inner(), pre);
+            }
+
+            if let Some(post) = submit_infos.post_barrier {
+                my_output.post_pipeline_barrier.add_buffer_barrier_request(self.buffer.inner(), post);
+            }
+        }
+
+        my_output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use buffer::BufferUsage;
+    use buffer::CpuAccessibleBuffer;
+    use command_buffer::std::PrimaryCbBuilder;
+    use command_buffer::std::StdCommandsList;
+    use command_buffer::submit::CommandBuffer;
+
+    #[test]
+    fn basic_submit() {
+        let (device, queue) = gfx_dev_and_queue!();
+
+        let buffer = CpuAccessibleBuffer::from_data(&device, &BufferUsage::transfer_dest(),
+                                                    Some(queue.family()), 0u32).unwrap();
+
+        let _ = PrimaryCbBuilder::new(&device, queue.family())
+                    .update_buffer(buffer.clone(), &128u32)
+                    .build()
+                    .submit(&queue);
+
+        let content = buffer.read(Duration::from_secs(0)).unwrap();
+        assert_eq!(*content, 128);
+    }
+}


### PR DESCRIPTION
New design for command buffers. For the moment I added it as a secondary system alongside with the existing system. In the end the current system will be removed in favor of this one.

Ok, so how exactly does that work?

While we're building a command buffer, each buffer or image has a state associated to them. What this state actually is depends on the implementation of the buffer/image, but it typically contains the pipeline stages, access masks, whether the resources was read/written, and for images their layout.

Whenever a buffer or an image is used in a command in the command buffer building process, two steps are involved: first we retrieve the current state of the resource in the builder (which can be empty if the resource wasn't used yet), then we ask the state to mutate itself in order to accommodate for the usage.

Retrieving the current state of the resource is done with the help of the `is_same` method that is implemented on buffers and images. Thanks to this, it is possible to have multiple objects implement the Buffer or Image trait and make them share the same state. This should allow for designs such as multiple resources sharing the same memory. If you want to split a buffer/image into multiple sub-buffers or sub-images, you can also make `is_same` return false for the different sub-buffers/sub-images even when the underlying buffer/image is the same.

Asking the state to mutate itself is done through a method on the state that takes as parameter the way the buffer/image is used by the command, and can return an optional "pipeline barrier request". The command buffer builder must take these requests into account and can merge them. The request contains the range of positions where the barrier can be put, so that we're free to reorganize things a bit. Buffers and images can also generate a final pipeline barrier, so that we can change the layout or flush caches to the HOST stage when necessary.

In order to make this system work, the command buffer builder has changed. It now uses an iterator-like API where each command wraps around the previous builder. This allows us to keep strong types and makes it possible for the compiler to aggressively inline. This also means that it will be possible to rework descriptor sets and framebuffers to keep strong typing as well.

Once we call the `build` function, the state of each buffer/image is turned into a "finished" state that is simpler than the state in the builder. When a command buffer is submitted, we query the finished state of each buffer/image in order to know which barriers to add and which semaphores to wait upon.

**For the moment, there's only one command supported (updating a buffer) and only cpu-accessible buffers implement the new tracking system. Some implementations are placeholder and unsound. The tracking system for images isn't even there yet. This PR is meant to lay the design for the new system, and more PRs will come in the future to actually implement it correctly.**

The one unresolved question is how to handle the fact that the user may want to submit to multiple queues simultaneously. If you submit two command buffers that each use the same buffer and the same image, then the order in which the `on_submit` function is called is important. I think some sort of "pending semaphore" system can be added. In last resort, we can also switch back to the current system which is that a global lock prevents parallel submissions.
