### PR TITLE
Change template parameter of compiled commands list

### DIFF
--- a/vulkano/src/command_buffer/std/draw.rs
+++ b/vulkano/src/command_buffer/std/draw.rs
@@ -116,7 +116,7 @@ unsafe impl<'a, L, Pv, Pl, Prp, S, Pc> StdCommandsList for DrawCommand<'a, L, Pv
     where L: StdCommandsList, Pl: PipelineLayout, S: TrackedDescriptorSetsCollection, Pc: 'a
 {
     type Pool = L::Pool;
-    type Output = DrawCommandCb<L, Pv, Pl, Prp, S>;
+    type Output = DrawCommandCb<L::Output, Pv, Pl, Prp, S>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -264,10 +264,10 @@ unsafe impl<'a, L, Pv, Pl, Prp, S, Pc> InsideRenderPass for DrawCommand<'a, L, P
 
 /// Wraps around a command buffer and adds an update buffer command at the end of it.
 pub struct DrawCommandCb<L, Pv, Pl, Prp, S>
-    where L: StdCommandsList, Pl: PipelineLayout, S: TrackedDescriptorSetsCollection
+    where L: CommandBuffer, Pl: PipelineLayout, S: TrackedDescriptorSetsCollection
 {
     // The previous commands.
-    previous: L::Output,
+    previous: L,
     // The barrier. We store it here to keep it alive.
     pipeline: Arc<GraphicsPipeline<Pv, Pl, Prp>>,
     // The descriptor sets. Stored here to keep them alive.
@@ -279,13 +279,13 @@ pub struct DrawCommandCb<L, Pv, Pl, Prp, S>
 }
 
 unsafe impl<L, Pv, Pl, Prp, S> CommandBuffer for DrawCommandCb<L, Pv, Pl, Prp, S>
-    where L: StdCommandsList, Pl: PipelineLayout, S: TrackedDescriptorSetsCollection
+    where L: CommandBuffer, Pl: PipelineLayout, S: TrackedDescriptorSetsCollection
 {
     type Pool = L::Pool;
-    type SemaphoresWaitIterator = Chain<<L::Output as CommandBuffer>::SemaphoresWaitIterator,
+    type SemaphoresWaitIterator = Chain<L::SemaphoresWaitIterator,
                                         <S::Finished as TrackedDescriptorSetsCollectionFinished>::
                                             SemaphoresWaitIterator>;
-    type SemaphoresSignalIterator = Chain<<L::Output as CommandBuffer>::SemaphoresSignalIterator,
+    type SemaphoresSignalIterator = Chain<L::SemaphoresSignalIterator,
                                           <S::Finished as TrackedDescriptorSetsCollectionFinished>::
                                             SemaphoresSignalIterator>;
 

--- a/vulkano/src/command_buffer/std/render_pass.rs
+++ b/vulkano/src/command_buffer/std/render_pass.rs
@@ -73,7 +73,7 @@ unsafe impl<L, Rp, Rpf> StdCommandsList for BeginRenderPassCommand<L, Rp, Rpf>
     where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
 {
     type Pool = L::Pool;
-    type Output = BeginRenderPassCommandCb<L, Rp, Rpf>;
+    type Output = BeginRenderPassCommandCb<L::Output, Rp, Rpf>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -167,20 +167,20 @@ unsafe impl<L, Rp, Rpf> InsideRenderPass for BeginRenderPassCommand<L, Rp, Rpf>
 
 /// Wraps around a command buffer and adds an update buffer command at the end of it.
 pub struct BeginRenderPassCommandCb<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+    where L: CommandBuffer, Rp: RenderPass, Rpf: RenderPass
 {
     // The previous commands.
-    previous: L::Output,
+    previous: L,
     render_pass: Arc<Rp>,
     framebuffer: Arc<Framebuffer<Rpf>>,
 }
 
 unsafe impl<L, Rp, Rpf> CommandBuffer for BeginRenderPassCommandCb<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+    where L: CommandBuffer, Rp: RenderPass, Rpf: RenderPass
 {
     type Pool = L::Pool;
-    type SemaphoresWaitIterator = <L::Output as CommandBuffer>::SemaphoresWaitIterator;
-    type SemaphoresSignalIterator = <L::Output as CommandBuffer>::SemaphoresSignalIterator;
+    type SemaphoresWaitIterator = L::SemaphoresWaitIterator;
+    type SemaphoresSignalIterator = L::SemaphoresSignalIterator;
 
     #[inline]
     fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
@@ -223,7 +223,7 @@ unsafe impl<L> StdCommandsList for NextSubpassCommand<L>
     where L: StdCommandsList + InsideRenderPass
 {
     type Pool = L::Pool;
-    type Output = NextSubpassCommandCb<L>;
+    type Output = NextSubpassCommandCb<L::Output>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -305,15 +305,15 @@ unsafe impl<L> InsideRenderPass for NextSubpassCommand<L>
 }
 
 /// Wraps around a command buffer and adds an end render pass command at the end of it.
-pub struct NextSubpassCommandCb<L> where L: StdCommandsList {
+pub struct NextSubpassCommandCb<L> where L: CommandBuffer {
     // The previous commands.
-    previous: L::Output,
+    previous: L,
 }
 
-unsafe impl<L> CommandBuffer for NextSubpassCommandCb<L> where L: StdCommandsList {
+unsafe impl<L> CommandBuffer for NextSubpassCommandCb<L> where L: CommandBuffer {
     type Pool = L::Pool;
-    type SemaphoresWaitIterator = <L::Output as CommandBuffer>::SemaphoresWaitIterator;
-    type SemaphoresSignalIterator = <L::Output as CommandBuffer>::SemaphoresSignalIterator;
+    type SemaphoresWaitIterator = L::SemaphoresWaitIterator;
+    type SemaphoresSignalIterator = L::SemaphoresSignalIterator;
 
     #[inline]
     fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {
@@ -350,7 +350,7 @@ impl<L> EndRenderPassCommand<L> where L: StdCommandsList + InsideRenderPass {
 
 unsafe impl<L> StdCommandsList for EndRenderPassCommand<L> where L: StdCommandsList {
     type Pool = L::Pool;
-    type Output = EndRenderPassCommandCb<L>;
+    type Output = EndRenderPassCommandCb<L::Output>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -416,15 +416,15 @@ unsafe impl<L> OutsideRenderPass for EndRenderPassCommand<L> where L: StdCommand
 }
 
 /// Wraps around a command buffer and adds an end render pass command at the end of it.
-pub struct EndRenderPassCommandCb<L> where L: StdCommandsList {
+pub struct EndRenderPassCommandCb<L> where L: CommandBuffer {
     // The previous commands.
-    previous: L::Output,
+    previous: L,
 }
 
-unsafe impl<L> CommandBuffer for EndRenderPassCommandCb<L> where L: StdCommandsList {
+unsafe impl<L> CommandBuffer for EndRenderPassCommandCb<L> where L: CommandBuffer {
     type Pool = L::Pool;
-    type SemaphoresWaitIterator = <L::Output as CommandBuffer>::SemaphoresWaitIterator;
-    type SemaphoresSignalIterator = <L::Output as CommandBuffer>::SemaphoresSignalIterator;
+    type SemaphoresWaitIterator = L::SemaphoresWaitIterator;
+    type SemaphoresSignalIterator = L::SemaphoresSignalIterator;
 
     #[inline]
     fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool> {

--- a/vulkano/src/command_buffer/std/update_buffer.rs
+++ b/vulkano/src/command_buffer/std/update_buffer.rs
@@ -88,7 +88,7 @@ unsafe impl<'a, L, B, D: ?Sized> StdCommandsList for UpdateCommand<'a, L, B, D>
           D: Copy + 'static,
 {
     type Pool = L::Pool;
-    type Output = UpdateCommandCb<L, B>;
+    type Output = UpdateCommandCb<L::Output, B>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -202,9 +202,9 @@ unsafe impl<'a, L, B, D: ?Sized> OutsideRenderPass for UpdateCommand<'a, L, B, D
 }
 
 /// Wraps around a command buffer and adds an update buffer command at the end of it.
-pub struct UpdateCommandCb<L, B> where B: TrackedBuffer, L: StdCommandsList {
+pub struct UpdateCommandCb<L, B> where B: TrackedBuffer, L: CommandBuffer {
     // The previous commands.
-    previous: L::Output,
+    previous: L,
     // The buffer to update.
     buffer: B,
     // The state of the buffer to update, or `None` if we don't manage it. Will be used to
@@ -213,12 +213,12 @@ pub struct UpdateCommandCb<L, B> where B: TrackedBuffer, L: StdCommandsList {
 }
 
 unsafe impl<L, B> CommandBuffer for UpdateCommandCb<L, B>
-    where B: TrackedBuffer, L: StdCommandsList
+    where B: TrackedBuffer, L: CommandBuffer
 {
     type Pool = L::Pool;
-    type SemaphoresWaitIterator = Chain<<L::Output as CommandBuffer>::SemaphoresWaitIterator,
+    type SemaphoresWaitIterator = Chain<L::SemaphoresWaitIterator,
                                         OptionIntoIter<(Arc<Semaphore>, PipelineStages)>>;
-    type SemaphoresSignalIterator = Chain<<L::Output as CommandBuffer>::SemaphoresSignalIterator,
+    type SemaphoresSignalIterator = Chain<L::SemaphoresSignalIterator,
                                           OptionIntoIter<Arc<Semaphore>>>;
 
     #[inline]


### PR DESCRIPTION
Because of https://github.com/rust-lang/rust/issues/35852 we can't use `CommandBuffer<ParentList>`. Instead we have to use `CommandBuffer<ParentCommandBuffer>`.