### PR TITLE
Extract the state-extraction functions to their own trait

### DIFF
--- a/vulkano/src/command_buffer/std/draw.rs
+++ b/vulkano/src/command_buffer/std/draw.rs
@@ -16,6 +16,7 @@ use buffer::traits::Buffer;
 use buffer::traits::TrackedBuffer;
 use command_buffer::DynamicState;
 use command_buffer::std::InsideRenderPass;
+use command_buffer::std::ResourcesStates;
 use command_buffer::std::StdCommandsList;
 use command_buffer::submit::CommandBuffer;
 use command_buffer::submit::SubmitInfo;
@@ -88,7 +89,7 @@ impl<'a, L, Pv, Pl, Prp, S, Pc> DrawCommand<'a, L, Pv, Pl, Prp, S, Pc>
         where Pv: Source<V>
     {
         let (sets_state, barrier_loc, barrier) = unsafe {
-            sets.extract_from_commands_list_and_transition(&mut previous)
+            sets.extract_states_and_transition(&mut previous)
         };
 
         // FIXME: lot of stuff missing here
@@ -132,27 +133,6 @@ unsafe impl<'a, L, Pv, Pl, Prp, S, Pc> StdCommandsList for DrawCommand<'a, L, Pv
         }
 
         self.previous.check_queue_validity(queue)
-    }
-
-    unsafe fn extract_current_buffer_state<Ob>(&mut self, buffer: &Ob)
-                                               -> Option<Ob::CommandListState>
-        where Ob: TrackedBuffer
-    {
-        if let Some(s) = self.sets_state.extract_buffer_state(buffer) {
-            return Some(s);
-        }
-
-        self.previous.extract_current_buffer_state(buffer)
-    }
-
-    unsafe fn extract_current_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
-        where I: TrackedImage
-    {
-        if let Some(s) = self.sets_state.extract_image_state(image) {
-            return Some(s);
-        }
-
-        self.previous.extract_current_image_state(image)
     }
 
     #[inline]
@@ -250,6 +230,32 @@ unsafe impl<'a, L, Pv, Pl, Prp, S, Pc> StdCommandsList for DrawCommand<'a, L, Pv
             sets_state: finished_state,
             vertex_buffers: my_vertex_buffers,
         }
+    }
+}
+
+unsafe impl<'a, L, Pv, Pl, Prp, S, Pc> ResourcesStates for DrawCommand<'a, L, Pv, Pl, Prp, S, Pc>
+    where L: StdCommandsList, Pl: PipelineLayout,
+          S: TrackedDescriptorSetsCollection, Pc: 'a
+{
+    unsafe fn extract_buffer_state<Ob>(&mut self, buffer: &Ob)
+                                               -> Option<Ob::CommandListState>
+        where Ob: TrackedBuffer
+    {
+        if let Some(s) = self.sets_state.extract_buffer_state(buffer) {
+            return Some(s);
+        }
+
+        self.previous.extract_buffer_state(buffer)
+    }
+
+    unsafe fn extract_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
+        where I: TrackedImage
+    {
+        if let Some(s) = self.sets_state.extract_image_state(image) {
+            return Some(s);
+        }
+
+        self.previous.extract_image_state(image)
     }
 }
 

--- a/vulkano/src/command_buffer/std/empty.rs
+++ b/vulkano/src/command_buffer/std/empty.rs
@@ -15,6 +15,7 @@ use buffer::traits::TrackedBuffer;
 use command_buffer::pool::CommandPool;
 use command_buffer::pool::StandardCommandPool;
 use command_buffer::std::OutsideRenderPass;
+use command_buffer::std::ResourcesStates;
 use command_buffer::std::StdCommandsList;
 use command_buffer::submit::CommandBuffer;
 use command_buffer::submit::SubmitInfo;
@@ -74,20 +75,6 @@ unsafe impl<P> StdCommandsList for PrimaryCbBuilder<P> where P: CommandPool {
     }
 
     #[inline]
-    unsafe fn extract_current_buffer_state<B>(&mut self, buffer: &B) -> Option<B::CommandListState>
-        where B: TrackedBuffer
-    {
-        None
-    }
-
-    #[inline]
-    unsafe fn extract_current_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
-        where I: TrackedImage
-    {
-        None
-    }
-
-    #[inline]
     fn is_compute_pipeline_bound<Pl>(&self, pipeline: &Arc<ComputePipeline<Pl>>) -> bool {
 
         false
@@ -129,6 +116,22 @@ unsafe impl<P> StdCommandsList for PrimaryCbBuilder<P> where P: CommandPool {
         PrimaryCb {
             cb: cb.build().unwrap(),        // TODO: handle error
         }
+    }
+}
+
+unsafe impl<P> ResourcesStates for PrimaryCbBuilder<P> where P: CommandPool {
+    #[inline]
+    unsafe fn extract_buffer_state<B>(&mut self, buffer: &B) -> Option<B::CommandListState>
+        where B: TrackedBuffer
+    {
+        None
+    }
+
+    #[inline]
+    unsafe fn extract_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
+        where I: TrackedImage
+    {
+        None
     }
 }
 

--- a/vulkano/src/command_buffer/std/render_pass.rs
+++ b/vulkano/src/command_buffer/std/render_pass.rs
@@ -15,6 +15,7 @@ use smallvec::SmallVec;
 use buffer::traits::TrackedBuffer;
 use command_buffer::std::InsideRenderPass;
 use command_buffer::std::OutsideRenderPass;
+use command_buffer::std::ResourcesStates;
 use command_buffer::std::StdCommandsList;
 use command_buffer::submit::CommandBuffer;
 use command_buffer::submit::SubmitInfo;
@@ -97,21 +98,6 @@ unsafe impl<L, Rp, Rpf> StdCommandsList for BeginRenderPassCommand<L, Rp, Rpf>
         false
     }
 
-    unsafe fn extract_current_buffer_state<Ob>(&mut self, buffer: &Ob)
-                                               -> Option<Ob::CommandListState>
-        where Ob: TrackedBuffer
-    {
-        // FIXME: state of images in the framebuffer
-        self.previous.extract_current_buffer_state(buffer)
-    }
-
-    unsafe fn extract_current_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
-        where I: TrackedImage
-    {
-        // FIXME: state of images in the framebuffer
-        self.previous.extract_current_image_state(image)
-    }
-
     #[inline]
     fn is_compute_pipeline_bound<Pl>(&self, pipeline: &Arc<ComputePipeline<Pl>>) -> bool {
 
@@ -150,6 +136,25 @@ unsafe impl<L, Rp, Rpf> StdCommandsList for BeginRenderPassCommand<L, Rp, Rpf>
             render_pass: my_render_pass,
             framebuffer: my_framebuffer,
         }
+    }
+}
+
+unsafe impl<L, Rp, Rpf> ResourcesStates for BeginRenderPassCommand<L, Rp, Rpf>
+    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+{
+    unsafe fn extract_buffer_state<Ob>(&mut self, buffer: &Ob)
+                                               -> Option<Ob::CommandListState>
+        where Ob: TrackedBuffer
+    {
+        // FIXME: state of images in the framebuffer
+        self.previous.extract_buffer_state(buffer)
+    }
+
+    unsafe fn extract_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
+        where I: TrackedImage
+    {
+        // FIXME: state of images in the framebuffer
+        self.previous.extract_image_state(image)
     }
 }
 
@@ -260,21 +265,6 @@ unsafe impl<L> StdCommandsList for NextSubpassCommand<L>
     }
 
     #[inline]
-    unsafe fn extract_current_buffer_state<Ob>(&mut self, buffer: &Ob)
-                                               -> Option<Ob::CommandListState>
-        where Ob: TrackedBuffer
-    {
-        self.previous.extract_current_buffer_state(buffer)
-    }
-
-    #[inline]
-    unsafe fn extract_current_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
-        where I: TrackedImage
-    {
-        self.previous.extract_current_image_state(image)
-    }
-
-    #[inline]
     fn is_compute_pipeline_bound<Pl>(&self, pipeline: &Arc<ComputePipeline<Pl>>) -> bool {
 
         self.previous.is_compute_pipeline_bound(pipeline)
@@ -302,6 +292,25 @@ unsafe impl<L> StdCommandsList for NextSubpassCommand<L>
         NextSubpassCommandCb {
             previous: parent,
         }
+    }
+}
+
+unsafe impl<L> ResourcesStates for NextSubpassCommand<L>
+    where L: StdCommandsList + InsideRenderPass
+{
+    #[inline]
+    unsafe fn extract_buffer_state<Ob>(&mut self, buffer: &Ob)
+                                               -> Option<Ob::CommandListState>
+        where Ob: TrackedBuffer
+    {
+        self.previous.extract_buffer_state(buffer)
+    }
+
+    #[inline]
+    unsafe fn extract_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
+        where I: TrackedImage
+    {
+        self.previous.extract_image_state(image)
     }
 }
 
@@ -400,21 +409,6 @@ unsafe impl<L> StdCommandsList for EndRenderPassCommand<L> where L: StdCommandsL
     }
 
     #[inline]
-    unsafe fn extract_current_buffer_state<Ob>(&mut self, buffer: &Ob)
-                                               -> Option<Ob::CommandListState>
-        where Ob: TrackedBuffer
-    {
-        self.previous.extract_current_buffer_state(buffer)
-    }
-
-    #[inline]
-    unsafe fn extract_current_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
-        where I: TrackedImage
-    {
-        self.previous.extract_current_image_state(image)
-    }
-
-    #[inline]
     fn is_compute_pipeline_bound<Pl>(&self, pipeline: &Arc<ComputePipeline<Pl>>) -> bool {
 
         self.previous.is_compute_pipeline_bound(pipeline)
@@ -450,6 +444,23 @@ unsafe impl<L> StdCommandsList for EndRenderPassCommand<L> where L: StdCommandsL
         EndRenderPassCommandCb {
             previous: parent,
         }
+    }
+}
+
+unsafe impl<L> ResourcesStates for EndRenderPassCommand<L> where L: StdCommandsList {
+    #[inline]
+    unsafe fn extract_buffer_state<Ob>(&mut self, buffer: &Ob)
+                                               -> Option<Ob::CommandListState>
+        where Ob: TrackedBuffer
+    {
+        self.previous.extract_buffer_state(buffer)
+    }
+
+    #[inline]
+    unsafe fn extract_image_state<I>(&mut self, image: &I) -> Option<I::CommandListState>
+        where I: TrackedImage
+    {
+        self.previous.extract_image_state(image)
     }
 }
 

--- a/vulkano/src/descriptor/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor/descriptor_set/mod.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use buffer::traits::TrackedBuffer;
-use command_buffer::std::StdCommandsList;
+use command_buffer::std::ResourcesStates;
 use command_buffer::submit::SubmitInfo;
 use command_buffer::sys::PipelineBarrierBuilder;
 use descriptor::descriptor::DescriptorDesc;
@@ -57,15 +57,15 @@ pub unsafe trait TrackedDescriptorSet: DescriptorSet {
     type State: TrackedDescriptorSetState<Finished = Self::Finished>;
     type Finished: TrackedDescriptorSetFinished;
 
-    /// Extracts from the commands list the states relevant to the buffers and images contained in
-    /// the descriptor set. Then transitions them to the right state.
-    unsafe fn extract_from_commands_list_and_transition<L>(&self, list: &mut L)
-                                                    -> (Self::State, usize, PipelineBarrierBuilder)
-        where L: StdCommandsList;
+    /// Extracts the states relevant to the buffers and images contained in the descriptor set.
+    /// Then transitions them to the right state.
+    unsafe fn extract_states_and_transition<L>(&self, list: &mut L)
+                                               -> (Self::State, usize, PipelineBarrierBuilder)
+        where L: ResourcesStates;
 }
 
 // TODO: re-read docs
-pub unsafe trait TrackedDescriptorSetState {
+pub unsafe trait TrackedDescriptorSetState: ResourcesStates {
     type Finished: TrackedDescriptorSetFinished;
 
     /// Extracts the state of a buffer of the descriptor set, or `None` if the buffer isn't in
@@ -83,7 +83,7 @@ pub unsafe trait TrackedDescriptorSetState {
 
     /// Returns the state of an image, or `None` if the image isn't in the descriptor set.
     ///
-    /// See the description of `extract_current_buffer_state`.
+    /// See the description of `extract_buffer_state`.
     ///
     /// # Panic
     ///


### PR DESCRIPTION
Instead of having multiple instances of `extract_*_buffer/image_state` functions, we put them in a trait of their own.

This change is also necessary so that the `draw` function can ask the descriptor sets to extract the states from the concatenation of the commands list and the local vertex buffers and index buffer.