### PR TITLE
Turn Framebuffer into a trait

### DIFF
--- a/vulkano/src/command_buffer/std/empty.rs
+++ b/vulkano/src/command_buffer/std/empty.rs
@@ -27,6 +27,7 @@ use command_buffer::sys::Kind;
 use device::Device;
 use device::Queue;
 use framebuffer::EmptySinglePassRenderPass;
+use framebuffer::Framebuffer as OldFramebuffer;
 use image::traits::TrackedImage;
 use instance::QueueFamily;
 use pipeline::ComputePipeline;
@@ -97,7 +98,7 @@ unsafe impl<P> StdCommandsList for PrimaryCbBuilder<P> where P: CommandPool {
         where F: FnOnce(&mut UnsafeCommandBufferBuilder<Self::Pool>),
               I: Iterator<Item = (usize, PipelineBarrierBuilder)>
     {
-        let kind = Kind::Primary::<EmptySinglePassRenderPass, EmptySinglePassRenderPass>;
+        let kind = Kind::Primary::<EmptySinglePassRenderPass, OldFramebuffer<EmptySinglePassRenderPass>>;
         let mut cb = UnsafeCommandBufferBuilder::new(self.pool, kind,
                                                      self.flags).unwrap();  // TODO: handle error
 

--- a/vulkano/src/command_buffer/std/render_pass.rs
+++ b/vulkano/src/command_buffer/std/render_pass.rs
@@ -47,8 +47,8 @@ pub struct BeginRenderPassCommand<L, Rp, F>
     framebuffer: F,
 }
 
-impl<L, Rp, F> BeginRenderPassCommand<L, Rp, F>
-    where L: StdCommandsList + OutsideRenderPass, Rp: RenderPass, F: Framebuffer
+impl<L, F> BeginRenderPassCommand<L, F::RenderPass, F>
+    where L: StdCommandsList + OutsideRenderPass, F: Framebuffer
 {
     /// See the documentation of the `begin_render_pass` method.
     // TODO: allow setting more parameters

--- a/vulkano/src/command_buffer/std/render_pass.rs
+++ b/vulkano/src/command_buffer/std/render_pass.rs
@@ -24,7 +24,7 @@ use command_buffer::sys::UnsafeCommandBuffer;
 use command_buffer::sys::UnsafeCommandBufferBuilder;
 use device::Queue;
 use format::ClearValue;
-use framebuffer::Framebuffer;
+use framebuffer::traits::Framebuffer;
 use framebuffer::RenderPass;
 use framebuffer::RenderPassClearValues;
 use image::traits::TrackedImage;
@@ -34,8 +34,8 @@ use pipeline::GraphicsPipeline;
 use sync::Fence;
 
 /// Wraps around a commands list and adds an update buffer command at the end of it.
-pub struct BeginRenderPassCommand<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+pub struct BeginRenderPassCommand<L, Rp, F>
+    where L: StdCommandsList, Rp: RenderPass, F: Framebuffer
 {
     // Parent commands list.
     previous: L,
@@ -44,39 +44,42 @@ pub struct BeginRenderPassCommand<L, Rp, Rpf>
     rect: [Range<u32>; 2],
     clear_values: SmallVec<[ClearValue; 6]>,
     render_pass: Arc<Rp>,
-    framebuffer: Arc<Framebuffer<Rpf>>,
+    framebuffer: F,
 }
 
-impl<L, Rp> BeginRenderPassCommand<L, Rp, Rp>
-    where L: StdCommandsList + OutsideRenderPass, Rp: RenderPass
+impl<L, Rp, F> BeginRenderPassCommand<L, Rp, F>
+    where L: StdCommandsList + OutsideRenderPass, Rp: RenderPass, F: Framebuffer
 {
     /// See the documentation of the `begin_render_pass` method.
     // TODO: allow setting more parameters
-    pub fn new<C>(previous: L, framebuffer: Arc<Framebuffer<Rp>>, secondary: bool, clear_values: C)
-                  -> BeginRenderPassCommand<L, Rp, Rp>
-        where Rp: RenderPassClearValues<C>
+    pub fn new<C>(previous: L, framebuffer: F, secondary: bool, clear_values: C)
+                  -> BeginRenderPassCommand<L, F::RenderPass, F>
+        where F::RenderPass: RenderPassClearValues<C>
     {
         // FIXME: transition states of the images in the framebuffer
 
         let clear_values = framebuffer.render_pass().convert_clear_values(clear_values)
                                       .collect();
 
+        let rect = [0 .. framebuffer.dimensions()[0], 0 .. framebuffer.dimensions()[1]];
+        let render_pass = framebuffer.render_pass().clone();
+
         BeginRenderPassCommand {
             previous: previous,
             secondary: secondary,
-            rect: [0 .. framebuffer.width(), 0 .. framebuffer.height()],
+            rect: rect,
             clear_values: clear_values,
-            render_pass: framebuffer.render_pass().clone(),
-            framebuffer: framebuffer.clone(),
+            render_pass: render_pass,
+            framebuffer: framebuffer,
         }
     }
 }
 
-unsafe impl<L, Rp, Rpf> StdCommandsList for BeginRenderPassCommand<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+unsafe impl<L, Rp, Fb> StdCommandsList for BeginRenderPassCommand<L, Rp, Fb>
+    where L: StdCommandsList, Rp: RenderPass, Fb: Framebuffer
 {
     type Pool = L::Pool;
-    type Output = BeginRenderPassCommandCb<L::Output, Rp, Rpf>;
+    type Output = BeginRenderPassCommandCb<L::Output, Rp, Fb>;
 
     #[inline]
     fn num_commands(&self) -> usize {
@@ -139,8 +142,8 @@ unsafe impl<L, Rp, Rpf> StdCommandsList for BeginRenderPassCommand<L, Rp, Rpf>
     }
 }
 
-unsafe impl<L, Rp, Rpf> ResourcesStates for BeginRenderPassCommand<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+unsafe impl<L, Rp, F> ResourcesStates for BeginRenderPassCommand<L, Rp, F>
+    where L: StdCommandsList, Rp: RenderPass, F: Framebuffer
 {
     unsafe fn extract_buffer_state<Ob>(&mut self, buffer: &Ob)
                                                -> Option<Ob::CommandListState>
@@ -158,11 +161,11 @@ unsafe impl<L, Rp, Rpf> ResourcesStates for BeginRenderPassCommand<L, Rp, Rpf>
     }
 }
 
-unsafe impl<L, Rp, Rpf> InsideRenderPass for BeginRenderPassCommand<L, Rp, Rpf>
-    where L: StdCommandsList, Rp: RenderPass, Rpf: RenderPass
+unsafe impl<L, Rp, F> InsideRenderPass for BeginRenderPassCommand<L, Rp, F>
+    where L: StdCommandsList, Rp: RenderPass, F: Framebuffer
 {
     type RenderPass = Rp;
-    type Framebuffer = Arc<Framebuffer<Rpf>>;
+    type Framebuffer = F;
 
     #[inline]
     fn current_subpass(&self) -> u32 {
@@ -186,17 +189,17 @@ unsafe impl<L, Rp, Rpf> InsideRenderPass for BeginRenderPassCommand<L, Rp, Rpf>
 }
 
 /// Wraps around a command buffer and adds an update buffer command at the end of it.
-pub struct BeginRenderPassCommandCb<L, Rp, Rpf>
-    where L: CommandBuffer, Rp: RenderPass, Rpf: RenderPass
+pub struct BeginRenderPassCommandCb<L, Rp, F>
+    where L: CommandBuffer, Rp: RenderPass, F: Framebuffer
 {
     // The previous commands.
     previous: L,
     render_pass: Arc<Rp>,
-    framebuffer: Arc<Framebuffer<Rpf>>,
+    framebuffer: F,
 }
 
-unsafe impl<L, Rp, Rpf> CommandBuffer for BeginRenderPassCommandCb<L, Rp, Rpf>
-    where L: CommandBuffer, Rp: RenderPass, Rpf: RenderPass
+unsafe impl<L, Rp, Fb> CommandBuffer for BeginRenderPassCommandCb<L, Rp, Fb>
+    where L: CommandBuffer, Rp: RenderPass, Fb: Framebuffer
 {
     type Pool = L::Pool;
     type SemaphoresWaitIterator = L::SemaphoresWaitIterator;

--- a/vulkano/src/command_buffer/submit.rs
+++ b/vulkano/src/command_buffer/submit.rs
@@ -21,6 +21,7 @@ use command_buffer::sys::UnsafeCommandBuffer;
 use device::Device;
 use device::Queue;
 use framebuffer::EmptySinglePassRenderPass;
+use framebuffer::Framebuffer as OldFramebuffer;
 use sync::Fence;
 use sync::PipelineStages;
 use sync::Semaphore;
@@ -291,7 +292,7 @@ unsafe impl<C, R> SubmitList for (C, R) where C: CommandBuffer + 'static, R: Sub
         if !current_infos.pre_pipeline_barrier.is_empty() {
             let mut cb = UnsafeCommandBufferBuilder::new(Device::standard_command_pool(&device, queue.family()),
                                                          Kind::Primary::<EmptySinglePassRenderPass,
-                                                                         EmptySinglePassRenderPass>,
+                                                                         OldFramebuffer<EmptySinglePassRenderPass>>,
                                                          Flags::OneTimeSubmit).unwrap();
             cb.pipeline_barrier(current_infos.pre_pipeline_barrier);
             new_submit.commandBufferCount += 1;
@@ -304,7 +305,7 @@ unsafe impl<C, R> SubmitList for (C, R) where C: CommandBuffer + 'static, R: Sub
         if !current_infos.post_pipeline_barrier.is_empty() {
             let mut cb = UnsafeCommandBufferBuilder::new(Device::standard_command_pool(&device, queue.family()),
                                                          Kind::Primary::<EmptySinglePassRenderPass,
-                                                                         EmptySinglePassRenderPass>,
+                                                                         OldFramebuffer<EmptySinglePassRenderPass>>,
                                                          Flags::OneTimeSubmit).unwrap();
             cb.pipeline_barrier(current_infos.post_pipeline_barrier);
             new_submit.commandBufferCount += 1;
@@ -349,6 +350,7 @@ mod tests {
     use device::Device;
     use device::Queue;
     use framebuffer::EmptySinglePassRenderPass;
+    use framebuffer::Framebuffer as OldFramebuffer;
     use sync::Fence;
     use sync::PipelineStages;
     use sync::Semaphore;
@@ -380,7 +382,7 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let pool = Device::standard_command_pool(&device, queue.family());
-        let kind = Kind::Primary::<EmptySinglePassRenderPass, EmptySinglePassRenderPass>;
+        let kind = Kind::Primary::<EmptySinglePassRenderPass, OldFramebuffer<EmptySinglePassRenderPass>>;
 
         let cb = UnsafeCommandBufferBuilder::new(pool, kind, Flags::OneTimeSubmit).unwrap();
         let cb = Basic { inner: cb.build().unwrap() };

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -691,9 +691,9 @@ impl<P> UnsafeCommandBufferBuilder<P> where P: CommandPool {
     /// - The render pass and the framebuffer must be compatible.
     /// - The clear values must be valid for the attachments.
     ///
-    pub unsafe fn begin_render_pass<L, I, F>(&mut self, render_pass: &UnsafeRenderPass,
-                                             framebuffer: &F, clear_values: I,
-                                             rect: [Range<u32>; 2], secondary: bool)
+    pub unsafe fn begin_render_pass<I, F>(&mut self, render_pass: &UnsafeRenderPass,
+                                          framebuffer: &F, clear_values: I,
+                                          rect: [Range<u32>; 2], secondary: bool)
         where I: Iterator<Item = ClearValue>,
               F: Framebuffer
     {

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -50,9 +50,9 @@ use device::Device;
 use format::ClearValue;
 use format::FormatTy;
 use framebuffer::RenderPass;
-use framebuffer::Framebuffer;
 use framebuffer::Subpass;
 use framebuffer::UnsafeRenderPass;
+use framebuffer::traits::Framebuffer;
 use image::Image;
 use image::sys::Layout;
 use image::sys::UnsafeImage;
@@ -86,10 +86,9 @@ pub struct UnsafeCommandBufferBuilder<P> where P: CommandPool {
 
 impl<P> UnsafeCommandBufferBuilder<P> where P: CommandPool {
     /// Creates a new builder.
-    pub fn new<R, Rf>(pool: P, kind: Kind<R, Rf>, flags: Flags)
-                      -> Result<UnsafeCommandBufferBuilder<P>, OomError>
-        where R: RenderPass + 'static + Send + Sync,
-              Rf: RenderPass + 'static + Send + Sync
+    pub fn new<R, F>(pool: P, kind: Kind<R, F>, flags: Flags)
+                     -> Result<UnsafeCommandBufferBuilder<P>, OomError>
+        where R: RenderPass, F: Framebuffer
     {
         let secondary = match kind {
             Kind::Primary => false,
@@ -115,11 +114,10 @@ impl<P> UnsafeCommandBufferBuilder<P> where P: CommandPool {
     /// - The allocated command buffer must belong to the pool and must not be used anywhere else
     ///   in the code for the duration of this command buffer.
     ///
-    pub unsafe fn already_allocated<R, Rf>(pool: P, cmd: AllocatedCommandBuffer,
-                                           kind: Kind<R, Rf>, flags: Flags)
-                                           -> Result<UnsafeCommandBufferBuilder<P>, OomError>
-        where R: RenderPass + 'static + Send + Sync,
-              Rf: RenderPass + 'static + Send + Sync
+    pub unsafe fn already_allocated<R, F>(pool: P, cmd: AllocatedCommandBuffer,
+                                          kind: Kind<R, F>, flags: Flags)
+                                          -> Result<UnsafeCommandBufferBuilder<P>, OomError>
+        where R: RenderPass, F: Framebuffer
     {
         let device = pool.device().clone();
         let vk = device.pointers();
@@ -149,7 +147,8 @@ impl<P> UnsafeCommandBufferBuilder<P> where P: CommandPool {
         };
 
         let framebuffer = if let Kind::SecondaryRenderPass { subpass, framebuffer: Some(ref framebuffer) } = kind {
-            assert!(framebuffer.is_compatible_with(subpass.render_pass()));     // TODO: proper error
+            // TODO: restore check
+            //assert!(framebuffer.is_compatible_with(subpass.render_pass()));     // TODO: proper error
             framebuffer.internal_object()
         } else {
             0
@@ -692,13 +691,15 @@ impl<P> UnsafeCommandBufferBuilder<P> where P: CommandPool {
     /// - The render pass and the framebuffer must be compatible.
     /// - The clear values must be valid for the attachments.
     ///
-    pub unsafe fn begin_render_pass<L, I>(&mut self, render_pass: &UnsafeRenderPass,
-                                          framebuffer: &Framebuffer<L>, clear_values: I,
-                                          rect: [Range<u32>; 2], secondary: bool)
-        where I: Iterator<Item = ClearValue>
+    pub unsafe fn begin_render_pass<L, I, F>(&mut self, render_pass: &UnsafeRenderPass,
+                                             framebuffer: &F, clear_values: I,
+                                             rect: [Range<u32>; 2], secondary: bool)
+        where I: Iterator<Item = ClearValue>,
+              F: Framebuffer
     {
-        assert_eq!(render_pass.device().internal_object(), framebuffer.device().internal_object());
-        assert_eq!(self.device.internal_object(), framebuffer.device().internal_object());
+        // TODO: restore these checks
+        //assert_eq!(render_pass.device().internal_object(), framebuffer.device().internal_object());
+        //assert_eq!(self.device.internal_object(), framebuffer.device().internal_object());
 
         let clear_values: SmallVec<[_; 12]> = clear_values.map(|clear_value| {
             match clear_value {
@@ -1029,7 +1030,7 @@ impl<P> Drop for UnsafeCommandBufferBuilder<P> where P: CommandPool {
 
 /// Determines the kind of command buffer that we want to create.
 #[derive(Clone)]        // TODO: Debug
-pub enum Kind<'a, R: 'a, Rf> {
+pub enum Kind<'a, R: 'a, F: 'a> {
     /// A primary command buffer can execute all commands and can call secondary command buffers.
     Primary,
 
@@ -1044,7 +1045,7 @@ pub enum Kind<'a, R: 'a, Rf> {
         subpass: Subpass<'a, R>,
         /// The framebuffer object that will be used when calling the command buffer.
         /// This parameter is optional and is an optimization hint for the implementation.
-        framebuffer: Option<Arc<Framebuffer<Rf>>>,
+        framebuffer: Option<&'a F>,
     },
 }
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -19,6 +19,7 @@ use framebuffer::RenderPass;
 use framebuffer::RenderPassAttachmentsList;
 use framebuffer::RenderPassCompatible;
 use framebuffer::UnsafeRenderPass;
+use framebuffer::traits::Framebuffer as FramebufferTrait;
 use image::Layout as ImageLayout;
 use image::traits::Image;
 use image::traits::ImageView;
@@ -172,6 +173,20 @@ impl<L> Framebuffer<L> {
     #[inline]
     pub fn attachments(&self) -> &[(Arc<ImageView>, Arc<Image>, ImageLayout, ImageLayout)] {
         &self.resources
+    }
+}
+
+unsafe impl<L> FramebufferTrait for Framebuffer<L> {
+    type RenderPass = L;
+
+    #[inline]
+    fn render_pass(&self) -> &Arc<Self::RenderPass> {
+        &self.render_pass
+    }
+
+    #[inline]
+    fn dimensions(&self) -> [u32; 2] {
+        [self.dimensions[0], self.dimensions[1]]
     }
 }
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -176,7 +176,7 @@ impl<L> Framebuffer<L> {
     }
 }
 
-unsafe impl<L> FramebufferTrait for Framebuffer<L> {
+unsafe impl<L> FramebufferTrait for Framebuffer<L> where L: RenderPass {
     type RenderPass = L;
 
     #[inline]

--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -26,7 +26,7 @@ use vk;
 use VulkanObject;
 
 pub unsafe trait Framebuffer: VulkanObject<Object = vk::Framebuffer> {
-    type RenderPass;
+    type RenderPass: RenderPass;
 
     // TODO: don't return an Arc
     fn render_pass(&self) -> &Arc<Self::RenderPass>;

--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -23,6 +23,17 @@ use sync::PipelineStages;
 
 use vk;
 
+use VulkanObject;
+
+pub unsafe trait Framebuffer: VulkanObject<Object = vk::Framebuffer> {
+    type RenderPass;
+
+    // TODO: don't return an Arc
+    fn render_pass(&self) -> &Arc<Self::RenderPass>;
+
+    fn dimensions(&self) -> [u32; 2];
+}
+
 /// Trait for objects that describe a render pass.
 ///
 /// # Safety


### PR DESCRIPTION
This PR is the first step towards making `Framebuffer` become a trait. There are two reasons for this change:

- Consistency. If you except Instance and Device, Framebuffer was the only object that was a real struct and not a trait. Most notably, Buffer, Image, Descriptor Set, Pipeline Layout, Render Pass, etc. are all traits.

- This will allow us to keep strong typing of the types of the attachments in the framebuffer object itself. It will be possible to get back the current behavior by using a `Box<Frambuffer<RenderPass = MyRenderPass>>` or a `Arc<Frambuffer<RenderPass = MyRenderPass>>`.
