### PR TITLE
vk-sys/vulkano{-win}: correct type of native window

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -17,6 +17,7 @@ use std::ffi::CString;
 use std::fmt;
 use std::os::raw::c_char;
 use std::os::raw::c_void;
+use std::os::raw::c_ulong;
 
 pub type Flags = u32;
 pub type Bool32 = u32;
@@ -2297,7 +2298,7 @@ pub struct XlibSurfaceCreateInfoKHR {
     pub pNext: *const c_void,
     pub flags: XlibSurfaceCreateFlagsKHR,
     pub dpy: *mut c_void,
-    pub window: *const c_void,
+    pub window: c_ulong,
 }
 
 pub type XcbSurfaceCreateFlagsKHR = Flags;
@@ -2308,7 +2309,7 @@ pub struct XcbSurfaceCreateInfoKHR {
     pub pNext: *const c_void,
     pub flags: XcbSurfaceCreateFlagsKHR,
     pub connection: *const c_void,
-    pub window: *const c_void,
+    pub window: u32,
 }
 
 

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -133,11 +133,11 @@ unsafe fn winit_to_surface(instance: &Arc<Instance>,
             if instance.loaded_extensions().khr_xlib_surface {
                 Surface::from_xlib(instance,
                                    win.get_xlib_display().unwrap(),
-                                   win.get_xlib_window().unwrap())
+                                   win.get_xlib_window().unwrap() as _)
             } else {
                 Surface::from_xcb(instance,
                                    win.get_xcb_connection().unwrap(),
-                                   win.get_xlib_window().unwrap())
+                                   win.get_xlib_window().unwrap() as _)
             }
         }
     }

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -10,6 +10,7 @@
 use std::error;
 use std::fmt;
 use std::mem;
+use std::os::raw::c_ulong;
 use std::ptr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -142,7 +143,7 @@ impl Surface {
     ///
     /// The caller must ensure that the `connection` and the `window` are both correct and stay
     /// alive for the entire lifetime of the surface.
-    pub unsafe fn from_xcb<C, W>(instance: &Arc<Instance>, connection: *const C, window: *const W)
+    pub unsafe fn from_xcb<C>(instance: &Arc<Instance>, connection: *const C, window: u32)
                                  -> Result<Arc<Surface>, SurfaceCreationError>
     {
         let vk = instance.pointers();
@@ -157,7 +158,7 @@ impl Surface {
                 pNext: ptr::null(),
                 flags: 0,   // reserved
                 connection: connection as *mut _,
-                window: window as *mut _,
+                window: window,
             };
 
             let mut output = mem::uninitialized();
@@ -181,7 +182,7 @@ impl Surface {
     ///
     /// The caller must ensure that the `display` and the `window` are both correct and stay
     /// alive for the entire lifetime of the surface.
-    pub unsafe fn from_xlib<D, W>(instance: &Arc<Instance>, display: *const D, window: *const W)
+    pub unsafe fn from_xlib<D>(instance: &Arc<Instance>, display: *const D, window: c_ulong)
                                   -> Result<Arc<Surface>, SurfaceCreationError>
     {
         let vk = instance.pointers();
@@ -196,7 +197,7 @@ impl Surface {
                 pNext: ptr::null(),
                 flags: 0,   // reserved
                 dpy: display as *mut _,
-                window: window as *mut _,
+                window: window,
             };
 
             let mut output = mem::uninitialized();
@@ -913,7 +914,7 @@ mod tests {
     #[test]
     fn khr_xcb_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xcb(&instance, ptr::null::<u8>(), ptr::null::<u8>()) } {
+        match unsafe { Surface::from_xcb(&instance, ptr::null::<u8>(), 0) } {
             Err(SurfaceCreationError::MissingExtension { .. }) => (),
             _ => panic!()
         }
@@ -922,7 +923,7 @@ mod tests {
     #[test]
     fn khr_xlib_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xlib(&instance, ptr::null::<u8>(), ptr::null::<u8>()) } {
+        match unsafe { Surface::from_xlib(&instance, ptr::null::<u8>(), 0) } {
             Err(SurfaceCreationError::MissingExtension { .. }) => (),
             _ => panic!()
         }


### PR DESCRIPTION
This commit changes the definitions for `window` in `XlibSurfaceCreateInfoKHR`
and `XcbSurfaceCreateInfoKHR` with to `u64` (xlib) and `u32` (xcb) (see
definitions below).

`vk-sys` defined `XlibSurfaceCreateInfoKHR` and `XcbSurfaceCreateInfoKHR` with
`pub window: *const c_void`. This propagates through to the API in
`vulkano::swapchain::Surface::from_{xlib,xcb}()`. As the native window types
in xcb/xlib are defined as unsigned ints, this may lead to the belief that a
pointer to such an integer is required. `vulkano` will create a `Surface` but
this surface will not be supported by any queue family.

xlib: https://cgit.freedesktop.org/xorg/proto/x11proto/tree/X.h#n96 and
      https://cgit.freedesktop.org/xorg/proto/x11proto/tree/X.h#n66

      (search `Windows`)

xcb: https://xcb.freedesktop.org/manual/group__XCB____API.html

    (search `xcb_window_t`)

(`winit` defines the field in `XWindow` correcty but casts into a `*mut c_void` in `get_xlib_window()`.)