### PR TITLE
Add support for cubemap images

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -13,7 +13,7 @@ extern crate vulkano;
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::format::Format;
 use vulkano::image::ImmutableImage;
-use vulkano::image::sys::Dimensions;
+use vulkano::image::Dimensions;
 use vulkano::instance;
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::instance::debug::{DebugCallback, MessageTypes};

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -107,7 +107,7 @@ fn main() {
         color: (vulkano::format::B8G8R8A8Srgb, 1)
     }).unwrap();
 
-    let texture = vulkano::image::immutable::ImmutableImage::new(&device, vulkano::image::sys::Dimensions::Dim2d { width: 93, height: 93 },
+    let texture = vulkano::image::immutable::ImmutableImage::new(&device, vulkano::image::Dimensions::Dim2d { width: 93, height: 93 },
                                                                  vulkano::format::R8G8B8A8Unorm, Some(queue.family())).unwrap();
 
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -136,3 +136,180 @@ impl Default for ComponentSwizzle {
         ComponentSwizzle::Identity
     }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Dimensions {
+    Dim1d { width: u32 },
+    Dim1dArray { width: u32, array_layers: u32 },
+    Dim2d { width: u32, height: u32 },
+    Dim2dArray { width: u32, height: u32, array_layers: u32 },
+    Dim3d { width: u32, height: u32, depth: u32 },
+    Cubemap { size: u32 },
+    CubemapArray { size: u32, array_layers: u32 },
+}
+
+impl Dimensions {
+    #[inline]
+    pub fn width(&self) -> u32 {
+        match *self {
+            Dimensions::Dim1d { width } => width,
+            Dimensions::Dim1dArray { width, .. } => width,
+            Dimensions::Dim2d { width, .. } => width,
+            Dimensions::Dim2dArray { width, .. } => width,
+            Dimensions::Dim3d { width, .. } => width,
+            Dimensions::Cubemap { size } => size,
+            Dimensions::CubemapArray { size, .. } => size,
+        }
+    }
+
+    #[inline]
+    pub fn height(&self) -> u32 {
+        match *self {
+            Dimensions::Dim1d { .. } => 1,
+            Dimensions::Dim1dArray { .. } => 1,
+            Dimensions::Dim2d { height, .. } => height,
+            Dimensions::Dim2dArray { height, .. } => height,
+            Dimensions::Dim3d { height, .. }  => height,
+            Dimensions::Cubemap { size } => size,
+            Dimensions::CubemapArray { size, .. } => size,
+        }
+    }
+
+    #[inline]
+    pub fn width_height(&self) -> [u32; 2] {
+        [self.width(), self.height()]
+    }
+
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        match *self {
+            Dimensions::Dim1d { .. } => 1,
+            Dimensions::Dim1dArray { .. } => 1,
+            Dimensions::Dim2d { .. } => 1,
+            Dimensions::Dim2dArray { .. } => 1,
+            Dimensions::Dim3d { depth, .. }  => depth,
+            Dimensions::Cubemap { .. } => 1,
+            Dimensions::CubemapArray { .. } => 1,
+        }
+    }
+
+    #[inline]
+    pub fn array_layers(&self) -> u32 {
+        match *self {
+            Dimensions::Dim1d { .. } => 1,
+            Dimensions::Dim1dArray { array_layers, .. } => array_layers,
+            Dimensions::Dim2d { .. } => 1,
+            Dimensions::Dim2dArray { array_layers, .. } => array_layers,
+            Dimensions::Dim3d { .. }  => 1,
+            Dimensions::Cubemap { .. } => 1,
+            Dimensions::CubemapArray { array_layers, .. } => array_layers,
+        }
+    }
+
+    /// Builds the corresponding `ImageDimensions`.
+    #[inline]
+    pub fn to_image_dimensions(&self) -> ImageDimensions {
+        match *self {
+            Dimensions::Dim1d { width } => {
+                ImageDimensions::Dim1d { width: width, array_layers: 1 }
+            },
+            Dimensions::Dim1dArray { width, array_layers } => {
+                ImageDimensions::Dim1d { width: width, array_layers: array_layers }
+            },
+            Dimensions::Dim2d { width, height } => {
+                ImageDimensions::Dim2d { width: width, height: height, array_layers: 1,
+                                         cubemap_compatible: false }
+            },
+            Dimensions::Dim2dArray { width, height, array_layers } => {
+                ImageDimensions::Dim2d { width: width, height: height,
+                                         array_layers: array_layers, cubemap_compatible: false }
+            },
+            Dimensions::Dim3d { width, height, depth } => {
+                ImageDimensions::Dim3d { width: width, height: height, depth: depth }
+            },
+            Dimensions::Cubemap { size } => {
+                ImageDimensions::Dim2d { width: size, height: size, array_layers: 6,
+                                         cubemap_compatible: true }
+            },
+            Dimensions::CubemapArray { size, array_layers } => {
+                ImageDimensions::Dim2d { width: size, height: size, array_layers: array_layers * 6,
+                                         cubemap_compatible: true }
+            },
+        }
+    }
+
+    /// Builds the corresponding `ViewType`.
+    #[inline]
+    pub fn to_view_type(&self) -> ViewType {
+        match *self {
+            Dimensions::Dim1d { .. } => ViewType::Dim1d, 
+            Dimensions::Dim1dArray { .. } => ViewType::Dim1dArray, 
+            Dimensions::Dim2d { .. } => ViewType::Dim2d, 
+            Dimensions::Dim2dArray { .. } => ViewType::Dim2dArray, 
+            Dimensions::Dim3d { .. } => ViewType::Dim3d, 
+            Dimensions::Cubemap { .. } => ViewType::Cubemap, 
+            Dimensions::CubemapArray { .. } => ViewType::CubemapArray, 
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ViewType {
+    Dim1d,
+    Dim1dArray,
+    Dim2d,
+    Dim2dArray,
+    Dim3d,
+    Cubemap,
+    CubemapArray,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ImageDimensions {
+    Dim1d { width: u32, array_layers: u32 },
+    Dim2d { width: u32, height: u32, array_layers: u32, cubemap_compatible: bool },
+    Dim3d { width: u32, height: u32, depth: u32 }
+}
+
+impl ImageDimensions {
+    #[inline]
+    pub fn width(&self) -> u32 {
+        match *self {
+            ImageDimensions::Dim1d { width, .. } => width,
+            ImageDimensions::Dim2d { width, .. } => width,
+            ImageDimensions::Dim3d { width, .. }  => width,
+        }
+    }
+
+    #[inline]
+    pub fn height(&self) -> u32 {
+        match *self {
+            ImageDimensions::Dim1d { .. } => 1,
+            ImageDimensions::Dim2d { height, .. } => height,
+            ImageDimensions::Dim3d { height, .. }  => height,
+        }
+    }
+
+    #[inline]
+    pub fn width_height(&self) -> [u32; 2] {
+        [self.width(), self.height()]
+    }
+
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        match *self {
+            ImageDimensions::Dim1d { .. } => 1,
+            ImageDimensions::Dim2d { .. } => 1,
+            ImageDimensions::Dim3d { depth, .. }  => depth,
+        }
+    }
+
+    #[inline]
+    pub fn array_layers(&self) -> u32 {
+        match *self {
+            ImageDimensions::Dim1d { array_layers, .. } => array_layers,
+            ImageDimensions::Dim2d { array_layers, .. } => array_layers,
+            ImageDimensions::Dim3d { .. }  => 1,
+        }
+    }
+}

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -18,6 +18,8 @@ use device::Queue;
 use format::ClearValue;
 use format::Format;
 use format::FormatDesc;
+use image::Dimensions;
+use image::ViewType;
 use image::traits::AccessRange;
 use image::traits::CommandBufferState;
 use image::traits::CommandListState;
@@ -78,7 +80,7 @@ impl SwapchainImage {
     pub unsafe fn from_raw(image: UnsafeImage, format: Format, swapchain: &Arc<Swapchain>, id: u32)
                            -> Result<Arc<SwapchainImage>, OomError>
     {
-        let view = try!(UnsafeImageView::raw(&image, 0 .. 1, 0 .. 1));
+        let view = try!(UnsafeImageView::raw(&image, ViewType::Dim2d, 0 .. 1, 0 .. 1));
 
         Ok(Arc::new(SwapchainImage {
             image: image,
@@ -221,6 +223,12 @@ unsafe impl ImageView for SwapchainImage {
     #[inline]
     fn parent_arc(me: &Arc<Self>) -> Arc<Image> where Self: Sized {
         me.clone() as Arc<_>
+    }
+
+    #[inline]
+    fn dimensions(&self) -> Dimensions {
+        let dims = self.image.dimensions();
+        Dimensions::Dim2d { width: dims.width(), height: dims.height() }
     }
 
     #[inline]

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -18,7 +18,8 @@ use command_buffer::Submission;
 use device::Queue;
 use format::ClearValue;
 use format::Format;
-use image::sys::Dimensions;
+use image::Dimensions;
+use image::ImageDimensions;
 use image::sys::Layout;
 use image::sys::UnsafeImage;
 use image::sys::UnsafeImageView;
@@ -51,7 +52,7 @@ pub unsafe trait Image: 'static + Send + Sync {
 
     /// Returns the dimensions of the image.
     #[inline]
-    fn dimensions(&self) -> Dimensions {
+    fn dimensions(&self) -> ImageDimensions {
         self.inner().dimensions()
     }
 
@@ -258,6 +259,9 @@ pub unsafe trait ImageView: 'static + Send + Sync {
     fn parent(&self) -> &Image;
 
     fn parent_arc(&Arc<Self>) -> Arc<Image> where Self: Sized;
+
+    /// Returns the dimensions of the image view.
+    fn dimensions(&self) -> Dimensions;
 
     /// Returns the inner unsafe image view object used by this image view.
     fn inner(&self) -> &UnsafeImageView;

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -20,7 +20,7 @@ use device::Device;
 use device::Queue;
 use format::Format;
 use format::FormatDesc;
-use image::sys::Dimensions;
+use image::ImageDimensions;
 use image::sys::UnsafeImage;
 use image::sys::Usage as ImageUsage;
 use image::swapchain::SwapchainImage;
@@ -214,7 +214,7 @@ impl Swapchain {
 
         let images = images.into_iter().enumerate().map(|(id, image)| unsafe {
             let unsafe_image = UnsafeImage::from_raw(device, image, usage, format,
-                                                     Dimensions::Dim2d { width: dimensions[0], height: dimensions[1] }, 1, 1);
+                                                     ImageDimensions::Dim2d { width: dimensions[0], height: dimensions[1], array_layers: 1, cubemap_compatible: false }, 1, 1);
             SwapchainImage::from_raw(unsafe_image, format, &swapchain, id as u32).unwrap()     // TODO: propagate error
         }).collect::<Vec<_>>();
 


### PR DESCRIPTION
The major public change is that `image::Dimensions` has two additional enum variants: `Cubemap` and `CubemapArray`.

There are other internal changes:
- Creating an image now takes an `ImageDimensions` (which is different from `Dimensions`)
- Creating an image view takes a `ViewType`.
- The `ImageView` trait has an additional `dimensions()` method.

This API is closer to what Vulkan proposes.