### PR TITLE
Print formatted GLSL compile error messages

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -47,7 +47,10 @@ pub fn build_glsl_shaders<'a, I>(shaders: I)
         let mut file_output = File::create(&dest.join("shaders").join(shader))
                                                         .expect("failed to open shader output");
 
-        let content = glsl_to_spirv::compile(&shader_content, ty).unwrap();
+        let content = match glsl_to_spirv::compile(&shader_content, ty) {
+            Ok(compiled) => compiled,
+            Err(message) => panic!("{}\nfailed to compile shader", message),
+        };
         let output = reflect("Shader", content).unwrap();
         write!(file_output, "{}", output).unwrap();
     }


### PR DESCRIPTION
By printing the GLSL compiler errors using `panic!` they are displayed in a better
readable format:
 
```
--- stderr
thread 'main' panicked at '/tmp/glslang-compile.AnsAni9wd0cG/0.comp
Warning, version 450 is not yet complete; most version-specific features are present, but some are missing.
ERROR: /tmp/glslang-compile.AnsAni9wd0cG/0.comp:82: 'UNDECL' : undeclared identifier 
ERROR: /tmp/glslang-compile.AnsAni9wd0cG/0.comp:81: '=' :  cannot convert from 'temp float' to 'global highp uint'
ERROR: /tmp/glslang-compile.AnsAni9wd0cG/0.comp:83: '' : compilation terminated 
ERROR: 3 compilation errors.  No code generated.



Linked compute stage:

ERROR: Linking compute stage: Missing entry point: Each stage requires one entry point

SPIR-V is not generated for failed compile or link

failed to compile shader', /home/alexd2580/.cargo/git/checkouts/vulkano-3405ac11b98870b4/format-glsl-errors/vulkano-shaders/src/lib.rs:52
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```