### PR TITLE
ensure macOS is excluded from unix target

### DIFF
--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -122,7 +122,7 @@ unsafe fn winit_to_surface(instance: &Arc<Instance>,
     Surface::from_anativewindow(instance, win.get_native_window())
 }
 
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
 unsafe fn winit_to_surface(instance: &Arc<Instance>,
                            win: &winit::Window)
                            -> Result<Arc<Surface>, SurfaceCreationError> {
@@ -145,7 +145,7 @@ unsafe fn winit_to_surface(instance: &Arc<Instance>,
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "windows")]
 unsafe fn winit_to_surface(instance: &Arc<Instance>,
                            win: &winit::Window)
                            -> Result<Arc<Surface>, SurfaceCreationError> {
@@ -155,7 +155,7 @@ unsafe fn winit_to_surface(instance: &Arc<Instance>,
                        win.get_hwnd())
 }
 
-#[cfg(macos)]
+#[cfg(target_os = "macos")]
 unsafe fn winit_to_surface(instance: &Arc<Instance>, win: &winit::Window)
                            -> Result<Arc<Surface>, SurfaceCreationError>
 {

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -19,7 +19,7 @@ use vk;
 lazy_static! {
     static ref VK_LIB: Result<shared_library::dynamic_library::DynamicLibrary, LoadingError> = {
         #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-        #[cfg(all(unix, not(target_os = "android")))] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
+        #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
         #[cfg(target_os = "android")] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
         #[cfg(any(target_os = "macos", target_os = "ios"))] fn get_path() -> &'static Path { Path::new("MoltenVK") }
         let path = get_path();


### PR DESCRIPTION
Fixes a few compile errors were linux targeted code ends up included in the macOS build.