### PR TITLE
Examples now use min_image_count-buffering

### DIFF
--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -52,7 +52,7 @@ fn main() {
         let present = caps.present_modes.iter().next().unwrap();
         let usage = caps.supported_usage_flags;
 
-        vulkano::swapchain::Swapchain::new(&device, &window.surface(), 3,
+        vulkano::swapchain::Swapchain::new(&device, &window.surface(), caps.min_image_count,
                                            vulkano::format::B8G8R8A8Srgb, dimensions, 1,
                                            &usage, &queue, vulkano::swapchain::SurfaceTransform::Identity,
                                            vulkano::swapchain::CompositeAlpha::Opaque,

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -59,7 +59,7 @@ fn main() {
         let usage = caps.supported_usage_flags;
         let format = caps.supported_formats[0].0;
 
-        vulkano::swapchain::Swapchain::new(&device, &window.surface(), 3, format, dimensions, 1,
+        vulkano::swapchain::Swapchain::new(&device, &window.surface(), caps.min_image_count, format, dimensions, 1,
                                            &usage, &queue, vulkano::swapchain::SurfaceTransform::Identity,
                                            vulkano::swapchain::CompositeAlpha::Opaque,
                                            present, true, None).expect("failed to create swapchain")

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -179,7 +179,7 @@ fn main() {
         let format = caps.supported_formats[0].0;
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
-        Swapchain::new(&device, &window.surface(), 2, format, dimensions, 1,
+        Swapchain::new(&device, &window.surface(), caps.min_image_count, format, dimensions, 1,
                        &caps.supported_usage_flags, &queue, SurfaceTransform::Identity, alpha,
                        present, true, None).expect("failed to create swapchain")
     };


### PR DESCRIPTION
This fixes a bug on some devices where the hard coded values were too small, and not supported.