### PR TITLE
Cleaner implementation of Debug for extensions structs

### DIFF
--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -11,6 +11,7 @@ use std::error;
 use std::ffi::CString;
 use std::fmt;
 use std::ptr;
+use std::str;
 
 use Error;
 use OomError;
@@ -22,7 +23,7 @@ use check_errors;
 macro_rules! extensions {
     ($sname:ident, $($ext:ident => $s:expr,)*) => (
         /// List of extensions that are enabled or available.
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[derive(Copy, Clone, PartialEq, Eq)]
         #[allow(missing_docs)]
         pub struct $sname {
             $(
@@ -62,6 +63,25 @@ macro_rules! extensions {
                     )*
                     _unbuildable: Unbuildable(())
                 }
+            }
+        }
+
+        impl fmt::Debug for $sname {
+            #[allow(unused_assignments)]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                try!(write!(f, "["));
+
+                let mut first = true;
+
+                $(
+                    if self.$ext {
+                        if !first { try!(write!(f, ", ")); }
+                        else { first = false; }
+                        try!(f.write_str(str::from_utf8($s).unwrap()));
+                    }
+                )*
+
+                write!(f, "]")
             }
         }
     );


### PR DESCRIPTION
Example result: `[VK_KHR_surface, VK_KHR_win32_surface, VK_EXT_debug_report]`.