### PR TITLE
Update reexports in module `vulkano::instance`

### DIFF
--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -123,6 +123,7 @@ pub use self::instance::Limits;
 pub use self::layers::layers_list;
 pub use self::layers::LayerProperties;
 pub use self::layers::LayersIterator;
+pub use self::layers::LayersListError;
 pub use self::loader::LoadingError;
 pub use version::Version;
 


### PR DESCRIPTION
This PR reexports `vulkano::instance::layers::LayersListError` to make it public-visible.

This is necessary because a former reexport `pub use self::layers::layers_list` introduces `Result<LayersIterator, LayersListError>` into the public interface. This in essence actually introduces a private type into the public interface.
Most of the times there would be no problem using values of this smuggled-out type. `pub`-implemented methods and trait methods can be invoked by outer code just as if the type *is* actually public visible. However, when the path to this type needs to be explicitly specified, like in the case when a consumer wants to chain this error type with `error-chain`, the compiler would complain that the type is not in scope. AFAIK the only way to to solve this is via another reexport, making this type really public-visible.

---

A quick example explaining what's going on there:

```rust
mod visible {
    pub use self::invisible::bomb_here;

    mod invisible {
        #[derive(Copy, Clone)]
        pub struct Oops { inner: i32 }

        impl Oops {
            pub fn inner(&self) -> i32 { self.inner }
        }

        pub fn bomb_here() -> Oops { Oops { inner : 1 } }
    }
}

fn main() {
    // This is OK:
    let oops = visible::bomb_here(); 

    // `Copy` is OK:
    let ooops = oops;

    // Method invocation is OK:
    let invisible = oops.inner(); 

    // BOOM! This won't compile. Explicitly specifying
    // the type name blows the compiler up:
    let boom: visible::invisible::Oops = oops;
                                     
}
```