### PR TITLE
Implement command pool trimming.

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -850,6 +850,7 @@ pub type CommandPoolResetFlagBits = u32;
 pub const COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT: u32 = 0x00000001;
 pub type CommandPoolResetFlags = Flags;
 
+pub type CommandPoolTrimFlagsKHR = Flags;
 
 pub type CommandBufferUsageFlagBits = u32;
 pub const COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT: u32 = 0x00000001;
@@ -2562,6 +2563,7 @@ ptrs!(DevicePointers, {
     CreateCommandPool => (device: Device, pCreateInfo: *const CommandPoolCreateInfo, pAllocator: *const AllocationCallbacks, pCommandPool: *mut CommandPool) -> Result,
     DestroyCommandPool => (device: Device, commandPool: CommandPool, pAllocator: *const AllocationCallbacks) -> (),
     ResetCommandPool => (device: Device, commandPool: CommandPool, flags: CommandPoolResetFlags) -> Result,
+    TrimCommandPoolKHR => (device: Device, commandPool: CommandPool, flags: CommandPoolTrimFlagsKHR) -> (),
     AllocateCommandBuffers => (device: Device, pAllocateInfo: *const CommandBufferAllocateInfo, pCommandBuffers: *mut CommandBuffer) -> Result,
     FreeCommandBuffers => (device: Device, commandPool: CommandPool, commandBufferCount: u32, pCommandBuffers: *const CommandBuffer) -> (),
     BeginCommandBuffer => (commandBuffer: CommandBuffer, pBeginInfo: *const CommandBufferBeginInfo) -> Result,

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -106,6 +106,19 @@ impl UnsafeCommandPool {
         Ok(())
     }
 
+    /// Trims a command pool, which recycles unused internal memory from the command pool back to the system.
+    ///
+    /// Command buffers allocated from the pool are not affected by trimming.
+    #[inline]
+    pub fn trim(&self) -> () {
+        assert!(self.device.loaded_extensions().khr_maintenance1); //TODO return error?
+        unsafe {
+            let flags = 0;
+            let vk = self.device.pointers();
+            vk.TrimCommandPoolKHR(self.device.internal_object(), self.pool, flags);
+        }
+    }
+
     /// Allocates `count` command buffers.
     ///
     /// If `secondary` is true, allocates secondary command buffers. Otherwise, allocates primary

--- a/vulkano/src/command_buffer/std/fill_buffer.rs
+++ b/vulkano/src/command_buffer/std/fill_buffer.rs
@@ -305,7 +305,6 @@ mod tests {
                     .fill_buffer(buffer.clone(), 128u32)
                     .build()
                     .submit(&queue);
-
         let content = buffer.read(Duration::from_secs(0)).unwrap();
         assert_eq!(*content, 128);
     }

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -29,7 +29,7 @@ macro_rules! extensions {
             $(
                 pub $ext: bool,
             )*
-            
+
             /// This field ensures that an instance of this `Extensions` struct
             /// can only be created through Vulkano functions and the update
             /// syntax. This way, extensions can be added to Vulkano without
@@ -93,7 +93,7 @@ macro_rules! instance_extensions {
             $sname,
             $( $ext => $s,)*
         }
-        
+
         impl $sname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<$sname, SupportedExtensionsError> {
@@ -103,14 +103,14 @@ macro_rules! instance_extensions {
                     let mut num = 0;
                     try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
                         ptr::null(), &mut num, ptr::null_mut())));
-                    
+
                     let mut properties = Vec::with_capacity(num as usize);
                     try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
                         ptr::null(), &mut num, properties.as_mut_ptr())));
                     properties.set_len(num as usize);
                     properties
                 };
-                
+
                 let mut extensions = $sname::none();
                 for property in properties {
                     let name = property.extensionName;
@@ -127,10 +127,10 @@ macro_rules! instance_extensions {
                         }
                     )*
                 }
-                
+
                 Ok(extensions)
             }
-            
+
             /// Returns an `Extensions` object with extensions supported by the core driver.
             pub fn supported_by_core() -> Result<$sname, LoadingError> {
                 match $sname::supported_by_core_raw() {
@@ -162,6 +162,7 @@ extensions! {
     DeviceExtensions,
     khr_swapchain => b"VK_KHR_swapchain",
     khr_display_swapchain => b"VK_KHR_display_swapchain",
+    khr_maintenance1 => b"VK_KHR_maintenance1",
 }
 
 /// Error that can happen when loading the list of layers.


### PR DESCRIPTION
As an exercise to re-familiarize myself with the vulkano codebase, I implemented trimming of `CommandPool`.

Work is based on https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VK_KHR_maintenance1
and https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#vkTrimCommandPoolKHR