### PR TITLE
Khr maintenance1 support

### DIFF
--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -106,6 +106,19 @@ impl UnsafeCommandPool {
         Ok(())
     }
 
+    /// Trims a command pool, which recycles unused internal memory from the command pool back to the system.
+    ///
+    /// Command buffers allocated from the pool are not affected by trimming.
+    #[inline]
+    pub fn trim(&self) -> () {
+        assert!(self.device.loaded_extensions().khr_maintenance1); //TODO return error?
+        unsafe {
+            let flags = 0;
+            let vk = self.device.pointers();
+            vk.TrimCommandPoolKHR(self.device.internal_object(), self.pool, flags);
+        }
+    }
+
     /// Allocates `count` command buffers.
     ///
     /// If `secondary` is true, allocates secondary command buffers. Otherwise, allocates primary

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -113,7 +113,7 @@ impl UnsafeCommandPool {
     ///
     /// Command buffers allocated from the pool are not affected by trimming.
     #[inline]
-    pub fn trim(&self) -> Result<(), CommandPoolTrimError> {
+    pub unsafe fn trim(&self) -> Result<(), CommandPoolTrimError> {
         if !self.device.loaded_extensions().khr_maintenance1 {
             return Err(CommandPoolTrimError::Maintenance1ExtensionNotEnabled);
         }

--- a/vulkano/src/descriptor/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor/descriptor_set/pool.rs
@@ -352,6 +352,9 @@ impl UnsafeDescriptorPool {
             vk::ERROR_OUT_OF_DEVICE_MEMORY => {
                 return Err(DescriptorPoolAllocError::OutOfDeviceMemory);
             },
+            vk::ERROR_OUT_OF_POOL_MEMORY_KHR => {
+                return Err(DescriptorPoolAllocError::OutOfPoolMemory);
+            },
             c if (c as i32) < 0 => {
                 return Err(DescriptorPoolAllocError::FragmentedPool);
             },
@@ -428,6 +431,8 @@ pub enum DescriptorPoolAllocError {
     OutOfDeviceMemory,
     /// Allocation has failed because the pool is too fragmented.
     FragmentedPool,
+    /// There is no more space available in the descriptor pool.
+    OutOfPoolMemory,
 }
 
 impl error::Error for DescriptorPoolAllocError {
@@ -443,6 +448,9 @@ impl error::Error for DescriptorPoolAllocError {
             DescriptorPoolAllocError::FragmentedPool => {
                 "allocation has failed because the pool is too fragmented"
             },
+            DescriptorPoolAllocError::OutOfPoolMemory => {
+                "There is no more space available in the descriptor pool"
+            }
         }
     }
 }
@@ -641,7 +649,7 @@ impl UnsafeDescriptorSet {
                 Some(off) => image_descriptors.as_ptr().offset(off as isize),
                 None => ptr::null()
             };
-            
+
             write.pBufferInfo = match raw_writes_buf_infos[i] {
                 Some(off) => buffer_descriptors.as_ptr().offset(off as isize),
                 None => ptr::null()
@@ -674,7 +682,7 @@ unsafe impl VulkanObject for UnsafeDescriptorSet {
 /// Represents a single write entry to a descriptor set.
 ///
 /// Use the various constructors to build a `DescriptorWrite`. While it is not unsafe to build a
-/// `DescriptorWrite`, it is unsafe to actually use it to write to a descriptor set. 
+/// `DescriptorWrite`, it is unsafe to actually use it to write to a descriptor set.
 pub struct DescriptorWrite {
     binding: u32,
     first_array_element: u32,

--- a/vulkano/src/descriptor/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor/descriptor_set/pool.rs
@@ -449,7 +449,7 @@ impl error::Error for DescriptorPoolAllocError {
                 "allocation has failed because the pool is too fragmented"
             },
             DescriptorPoolAllocError::OutOfPoolMemory => {
-                "There is no more space available in the descriptor pool"
+                "there is no more space available in the descriptor pool"
             }
         }
     }

--- a/vulkano/src/descriptor/descriptor_set/std_pool.rs
+++ b/vulkano/src/descriptor/descriptor_set/std_pool.rs
@@ -118,6 +118,8 @@ unsafe impl DescriptorPool for Arc<StdDescriptorPool> {
                 },
                 // A fragmented pool error can't happen at the first ever allocation.
                 Err(DescriptorPoolAllocError::FragmentedPool) => unreachable!(),
+                // Out of pool memory cannot happen at the first ever allocation.
+                Err(DescriptorPoolAllocError::OutOfPoolMemory) => unreachable!(),
             }
         };
 

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 //! Low-level implementation of images and images views.
-//! 
+//!
 //! This module contains low-level wrappers around the Vulkan image and image view types. All
 //! other image or image view types of this library, and all custom image or image view types
 //! that you create must wrap around the types in this module.
@@ -528,7 +528,7 @@ impl UnsafeImage {
     /// The layout is invariant for each image. However it is not cached, as this would waste
     /// memory in the case of non-linear-tiling images. You are encouraged to store the layout
     /// somewhere in order to avoid calling this semi-expensive function at every single memory
-    /// access. 
+    /// access.
     ///
     /// Note that while Vulkan allows querying the array layers other than 0, it is redundant as
     /// you can easily calculate the position of any layer.
@@ -864,7 +864,7 @@ impl UnsafeImageView {
             format: image.format,
         })
     }
-    
+
     /// Creates a new view from an image.
     ///
     /// Note that you must create the view with identity swizzling if you want to use this view

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -139,6 +139,14 @@ impl UnsafeImage {
             if usage.input_attachment && (features & (vk::FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | vk::FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
                 return Err(ImageCreationError::UnsupportedUsage);
             }
+            if device.loaded_extensions().khr_maintenance1 {
+                if usage.transfer_source && (features & vk::FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR == 0) {
+                    return Err(ImageCreationError::UnsupportedUsage);
+                }
+                if usage.transfer_dest && (features & vk::FORMAT_FEATURE_TRANSFER_DST_BIT_KHR == 0) {
+                    return Err(ImageCreationError::UnsupportedUsage);
+                }
+            }
 
             features
         };

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -210,6 +210,7 @@ device_extensions! {
     khr_swapchain => b"VK_KHR_swapchain",
     khr_display_swapchain => b"VK_KHR_display_swapchain",
     khr_sampler_mirror_clamp_to_edge => b"VK_KHR_sampler_mirror_clamp_to_edge",
+    khr_maintenance1 => b"VK_KHR_maintenance1",
 }
 
 /// Error that can happen when loading the list of layers.

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 //! Safe and rich Rust wrapper around the Vulkan API.
-//! 
+//!
 //! # Brief summary of Vulkan
 //!
 //! - The `Instance` object is the API entry point. It is the first object you must create before
@@ -196,6 +196,7 @@ pub enum Error {
     OutOfDate = vk::ERROR_OUT_OF_DATE_KHR,
     IncompatibleDisplay = vk::ERROR_INCOMPATIBLE_DISPLAY_KHR,
     ValidationFailed = vk::ERROR_VALIDATION_FAILED_EXT,
+    OutOfPoolMemory = vk::ERROR_OUT_OF_POOL_MEMORY_KHR,
 }
 
 /// Checks whether the result returned correctly.
@@ -224,6 +225,7 @@ fn check_errors(result: vk::Result) -> Result<Success, Error> {
         vk::ERROR_OUT_OF_DATE_KHR => Err(Error::OutOfDate),
         vk::ERROR_INCOMPATIBLE_DISPLAY_KHR => Err(Error::IncompatibleDisplay),
         vk::ERROR_VALIDATION_FAILED_EXT => Err(Error::ValidationFailed),
+        vk::ERROR_OUT_OF_POOL_MEMORY_KHR => Err(Error::OutOfPoolMemory),
         c => unreachable!("Unexpected error code returned by Vulkan: {}", c)
     }
 }


### PR DESCRIPTION
This patch series implements most of the stuff introduced by `VK_KHR_maintenance1`.
https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VK_KHR_maintenance1

I'm not really sure how to handle `VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR` , but I think it's fine to ignore for now.