### PR TITLE
Add IntoBuffer and IntoImage traits

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -37,6 +37,7 @@ use buffer::sys::UnsafeBuffer;
 use buffer::sys::Usage;
 use buffer::traits::Buffer;
 use buffer::traits::BufferInner;
+use buffer::traits::IntoBuffer;
 use buffer::traits::TypedBuffer;
 use device::Device;
 use device::DeviceOwned;
@@ -284,6 +285,18 @@ impl<T: ?Sized, A> CpuAccessibleBuffer<T, A> where T: Content + 'static, A: Memo
             inner: unsafe { self.memory.mapped_memory().unwrap().read_write(range) },
             lock: lock,
         })
+    }
+}
+
+// FIXME: wrong
+unsafe impl<T: ?Sized, A> IntoBuffer for Arc<CpuAccessibleBuffer<T, A>>
+    where T: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_buffer(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -32,6 +32,7 @@ use buffer::sys::UnsafeBuffer;
 use buffer::sys::Usage;
 use buffer::traits::Buffer;
 use buffer::traits::BufferInner;
+use buffer::traits::IntoBuffer;
 use buffer::traits::TypedBuffer;
 use device::Device;
 use device::DeviceOwned;
@@ -153,6 +154,18 @@ impl<T: ?Sized, A> ImmutableBuffer<T, A> where A: MemoryPool {
         self.queue_families.iter().map(|&num| {
             self.device().physical_device().queue_family_by_id(num).unwrap()
         }).collect()
+    }
+}
+
+// FIXME: wrong
+unsafe impl<T: ?Sized, A> IntoBuffer for Arc<ImmutableBuffer<T, A>>
+    where T: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_buffer(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -70,6 +70,7 @@ pub use self::sys::BufferCreationError;
 pub use self::sys::Usage as BufferUsage;
 pub use self::traits::Buffer;
 pub use self::traits::BufferInner;
+pub use self::traits::IntoBuffer;
 pub use self::traits::TypedBuffer;
 pub use self::view::BufferView;
 pub use self::view::BufferViewRef;

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use buffer::traits::Buffer;
 use buffer::traits::BufferInner;
 use buffer::traits::TypedBuffer;
+use buffer::traits::IntoBuffer;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
@@ -157,6 +158,15 @@ impl<T, B> BufferSlice<[T], B> {
             offset: self.offset + range.start * mem::size_of::<T>(),
             size: (range.end - range.start) * mem::size_of::<T>(),
         })
+    }
+}
+
+unsafe impl<T: ?Sized, B> IntoBuffer for BufferSlice<T, B> where B: Buffer {
+    type Target = Self;
+
+    #[inline]
+    fn into_buffer(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -167,6 +167,13 @@ pub unsafe trait Buffer: DeviceOwned {
     unsafe fn increase_gpu_lock(&self);
 }
 
+/// Utility trait.
+pub unsafe trait IntoBuffer {
+    type Target: Buffer;
+
+    fn into_buffer(self) -> Self::Target;
+}
+
 /// Inner information about a buffer.
 #[derive(Copy, Clone, Debug)]
 pub struct BufferInner<'a> {

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -130,6 +130,7 @@ impl<Rp> Framebuffer<Rp, Box<AttachmentsList>> {
     /// Builds a new framebuffer.
     ///
     /// The `attachments` parameter depends on which render pass implementation is used.
+    // TODO: allow IntoImageView
     pub fn new<Ia>(render_pass: Rp, dimensions: [u32; 3], attachments: Ia)
                    -> Result<Arc<Framebuffer<Rp, Box<AttachmentsList>>>, FramebufferCreationError>
         where Rp: RenderPassAbstract + RenderPassDescAttachmentsList<Ia>

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -29,6 +29,8 @@ use image::traits::Image;
 use image::traits::ImageClearValue;
 use image::traits::ImageContent;
 use image::traits::ImageView;
+use image::traits::IntoImage;
+use image::traits::IntoImageView;
 use memory::pool::AllocLayout;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
@@ -231,6 +233,30 @@ unsafe impl<P, F, A> ImageContent<P> for AttachmentImage<F, A>
     #[inline]
     fn matches_format(&self) -> bool {
         true        // FIXME:
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImage for Arc<AttachmentImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image(self) -> Self {
+        self
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImageView for Arc<AttachmentImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image_view(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -23,6 +23,8 @@ use image::sys::Usage;
 use image::traits::Image;
 use image::traits::ImageContent;
 use image::traits::ImageView;
+use image::traits::IntoImage;
+use image::traits::IntoImageView;
 use instance::QueueFamily;
 use memory::pool::AllocLayout;
 use memory::pool::MemoryPool;
@@ -103,6 +105,30 @@ impl<F, A> ImmutableImage<F, A> where A: MemoryPool {
     #[inline]
     pub fn dimensions(&self) -> Dimensions {
         self.dimensions
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImage for Arc<ImmutableImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image(self) -> Self {
+        self
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImageView for Arc<ImmutableImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image_view(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -55,6 +55,8 @@ pub use self::sys::Layout;
 pub use self::sys::Usage;
 pub use self::traits::Image;
 pub use self::traits::ImageView;
+pub use self::traits::IntoImage;
+pub use self::traits::IntoImageView;
 
 pub mod attachment;     // TODO: make private
 pub mod immutable;      // TODO: make private

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -28,6 +28,8 @@ use image::traits::Image;
 use image::traits::ImageClearValue;
 use image::traits::ImageContent;
 use image::traits::ImageView;
+use image::traits::IntoImage;
+use image::traits::IntoImageView;
 use instance::QueueFamily;
 use memory::pool::AllocLayout;
 use memory::pool::MemoryPool;
@@ -137,6 +139,30 @@ impl<F, A> StorageImage<F, A> where A: MemoryPool {
     #[inline]
     pub fn dimensions(&self) -> Dimensions {
         self.dimensions
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImage for Arc<StorageImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image(self) -> Self {
+        self
+    }
+}
+
+// FIXME: wrong
+unsafe impl<F, A> IntoImageView for Arc<StorageImage<F, A>>
+    where F: 'static + Send + Sync, A: MemoryPool
+{
+    type Target = Self;
+
+    #[inline]
+    fn into_image_view(self) -> Self {
+        self
     }
 }
 

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -19,6 +19,8 @@ use image::traits::Image;
 use image::traits::ImageClearValue;
 use image::traits::ImageContent;
 use image::traits::ImageView;
+use image::traits::IntoImage;
+use image::traits::IntoImageView;
 use image::sys::Layout;
 use image::sys::UnsafeImage;
 use image::sys::UnsafeImageView;
@@ -171,9 +173,34 @@ unsafe impl ImageView for SwapchainImage {
     }
 }
 
-pub struct SwapchainImageCbState {
-    stages: PipelineStages,
-    access: AccessFlagBits,
-    command_num: usize,
-    layout: Layout,
+unsafe impl IntoImage for SwapchainImage {
+    type Target = SwapchainImage;
+
+    fn into_image(self) -> Self::Target {
+        self
+    }
+}
+
+unsafe impl IntoImageView for SwapchainImage {
+    type Target = SwapchainImage;
+
+    fn into_image_view(self) -> Self::Target {
+        self
+    }
+}
+
+unsafe impl IntoImage for Arc<SwapchainImage> {
+    type Target = Arc<SwapchainImage>;
+
+    fn into_image(self) -> Self::Target {
+        self
+    }
+}
+
+unsafe impl IntoImageView for Arc<SwapchainImage> {
+    type Target = Arc<SwapchainImage>;
+
+    fn into_image_view(self) -> Self::Target {
+        self
+    }
 }

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -27,6 +27,13 @@ use sampler::Sampler;
 use SafeDeref;
 use VulkanObject;
 
+/// Utility trait.
+pub unsafe trait IntoImage {
+    type Target: Image;
+
+    fn into_image(self) -> Self::Target;
+}
+
 /// Trait for types that represent images.
 pub unsafe trait Image {
     /// Returns the inner unsafe image object used by this image.
@@ -188,6 +195,13 @@ pub unsafe trait ImageClearValue<T>: Image {
 pub unsafe trait ImageContent<P>: Image {
     /// Checks whether pixels of type `P` match the format of the image.
     fn matches_format(&self) -> bool;
+}
+
+/// Utility trait.
+pub unsafe trait IntoImageView {
+    type Target: ImageView;
+
+    fn into_image_view(self) -> Self::Target;
 }
 
 /// Trait for types that represent image views.


### PR DESCRIPTION
After the latest changes in submission stuff, whenever a resource is used in a submission it automatically gets locked and is unlocked only when the resource is destroyed.

This works nicely for "pool-like" types such as a `UploadBuffer` (yet to be actually written). The buffer would be subdivided into multiple "sub-buffers", and destroying the pseudo-object that represents of these subbuffers only frees the subbuffers (and not the buffer as a whole) and allows it to be reclaimed. Combined with the submission rework, this also unlocks the subbuffer.

However this doesn't work nicely for regular buffers. You usually want to pass an `Arc<MyBufferType>` for the buffer, and with the new submission stuff you would need to destroy the buffer entirely in order to unlock it. In other words once a buffer has been used in a submission it couldn't be used anymore.

In order to make it usable, we need an additional type named `MyBufferTypeAccess` that holds a `Arc<MyBufferType>` and that represents a GPU lock of the buffer. Destroying this object unlocks the buffer. But the consequence is that you'd need to call something like `my_buffer.gpu_access()` every time you use the buffer.

Therefore this PR adds new traits: `IntoBuffer`, `IntoImage` and `IntoImageView`, similar to `IntoIterator`. Using a buffer in a descriptor set, framebuffer or GPU command only requires a `Into*` trait. You don't need to call `gpu_access` manually, as it's done through these traits.
