### PR TITLE
Add Send/Sync bounds everywhere

### DIFF
--- a/vulkano/src/command_buffer/builder.rs
+++ b/vulkano/src/command_buffer/builder.rs
@@ -117,7 +117,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     #[inline]
     fn begin_render_pass<F, C, O>(self, framebuffer: F, secondary: bool, clear_values: C)
                                   -> O
-        where Self: Sized + AddCommand<cmd::CmdBeginRenderPass<Arc<RenderPassAbstract>, F>, Out = O>,
+        where Self: Sized + AddCommand<cmd::CmdBeginRenderPass<Arc<RenderPassAbstract + Send + Sync>, F>, Out = O>,
               F: FramebufferAbstract + RenderPassDescClearValues<C>
     {
         let cmd = cmd::CmdBeginRenderPass::new(framebuffer, secondary, clear_values);

--- a/vulkano/src/command_buffer/cb/abstract_storage.rs
+++ b/vulkano/src/command_buffer/cb/abstract_storage.rs
@@ -29,7 +29,7 @@ use sync::PipelineStages;
 /// Layer that stores commands in an abstract way.
 pub struct AbstractStorageLayer<I> {
     inner: I,
-    commands: Vec<Box<Any>>,
+    commands: Vec<Box<Any + Send + Sync>>,
 }
 
 impl<I> AbstractStorageLayer<I> {
@@ -100,7 +100,7 @@ unsafe impl<I> CommandBufferBuilder for AbstractStorageLayer<I> where I: DeviceO
 macro_rules! pass_through {
     (($($param:ident),*), $cmd:ty) => {
         unsafe impl<I $(, $param)*> AddCommand<$cmd> for AbstractStorageLayer<I>
-            where I: for<'r> AddCommand<&'r $cmd, Out = I>, $cmd: 'static
+            where I: for<'r> AddCommand<&'r $cmd, Out = I>, $cmd: Send + Sync + 'static
         {
             type Out = AbstractStorageLayer<I>;
 

--- a/vulkano/src/command_buffer/cb/submit_sync.rs
+++ b/vulkano/src/command_buffer/cb/submit_sync.rs
@@ -38,8 +38,8 @@ use sync::GpuFuture;
 ///
 pub struct SubmitSyncBuilderLayer<I> {
     inner: I,
-    buffers: Vec<(Box<Buffer>, bool)>,
-    images: Vec<(Box<Image>, bool)>,
+    buffers: Vec<(Box<Buffer + Send + Sync>, bool)>,
+    images: Vec<(Box<Image + Send + Sync>, bool)>,
 }
 
 impl<I> SubmitSyncBuilderLayer<I> {
@@ -55,7 +55,7 @@ impl<I> SubmitSyncBuilderLayer<I> {
 
     // Adds a buffer to the list.
     fn add_buffer<B>(&mut self, buffer: &B, exclusive: bool)
-        where B: Buffer + Clone + 'static
+        where B: Buffer + Send + Sync + Clone + 'static
     {
         for &mut (ref existing_buf, ref mut existing_exclusive) in self.buffers.iter_mut() {
             if existing_buf.conflicts_buffer(0, existing_buf.size(), buffer, 0, buffer.size()) {
@@ -71,7 +71,7 @@ impl<I> SubmitSyncBuilderLayer<I> {
 
     // Adds an image to the list.
     fn add_image<T>(&mut self, image: &T, exclusive: bool)
-        where T: Image + Clone + 'static
+        where T: Image + Send + Sync + Clone + 'static
     {
         // FIXME: actually implement
         self.images.push((Box::new(image.clone()), exclusive));
@@ -135,7 +135,7 @@ pass_through!((C), cmd::CmdExecuteCommands<C>);
 
 unsafe impl<I, O, B> AddCommand<cmd::CmdBindIndexBuffer<B>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdBindIndexBuffer<B>, Out = O>,
-          B: Buffer + Clone + 'static
+          B: Buffer + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -168,8 +168,8 @@ unsafe impl<I, O, P> AddCommand<cmd::CmdBindPipeline<P>> for SubmitSyncBuilderLa
 
 unsafe impl<I, O, S, D> AddCommand<cmd::CmdBlitImage<S, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdBlitImage<S, D>, Out = O>,
-          S: Image + Clone + 'static,
-          D: Image + Clone + 'static
+          S: Image + Send + Sync + Clone + 'static,
+          D: Image + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -203,8 +203,8 @@ unsafe impl<I, O> AddCommand<cmd::CmdClearAttachments> for SubmitSyncBuilderLaye
 
 unsafe impl<I, O, S, D> AddCommand<cmd::CmdCopyBuffer<S, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdCopyBuffer<S, D>, Out = O>,
-          S: Buffer + Clone + 'static,
-          D: Buffer + Clone + 'static
+          S: Buffer + Send + Sync + Clone + 'static,
+          D: Buffer + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -223,8 +223,8 @@ unsafe impl<I, O, S, D> AddCommand<cmd::CmdCopyBuffer<S, D>> for SubmitSyncBuild
 
 unsafe impl<I, O, S, D> AddCommand<cmd::CmdCopyBufferToImage<S, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdCopyBufferToImage<S, D>, Out = O>,
-          S: Buffer + Clone + 'static,
-          D: Image + Clone + 'static
+          S: Buffer + Send + Sync + Clone + 'static,
+          D: Image + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -243,8 +243,8 @@ unsafe impl<I, O, S, D> AddCommand<cmd::CmdCopyBufferToImage<S, D>> for SubmitSy
 
 unsafe impl<I, O, S, D> AddCommand<cmd::CmdCopyImage<S, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdCopyImage<S, D>, Out = O>,
-          S: Image + Clone + 'static,
-          D: Image + Clone + 'static
+          S: Image + Send + Sync + Clone + 'static,
+          D: Image + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -323,7 +323,7 @@ unsafe impl<I, O> AddCommand<cmd::CmdEndRenderPass> for SubmitSyncBuilderLayer<I
 
 unsafe impl<I, O, B> AddCommand<cmd::CmdFillBuffer<B>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdFillBuffer<B>, Out = O>,
-          B: Buffer + Clone + 'static
+          B: Buffer + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -371,8 +371,8 @@ unsafe impl<I, O, Pc, Pl> AddCommand<cmd::CmdPushConstants<Pc, Pl>> for SubmitSy
 
 unsafe impl<I, O, S, D> AddCommand<cmd::CmdResolveImage<S, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdResolveImage<S, D>, Out = O>,
-          S: Image + Clone + 'static,
-          D: Image + Clone + 'static
+          S: Image + Send + Sync + Clone + 'static,
+          D: Image + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -421,7 +421,7 @@ unsafe impl<I, O> AddCommand<cmd::CmdSetState> for SubmitSyncBuilderLayer<I>
 
 unsafe impl<I, O, B, D> AddCommand<cmd::CmdUpdateBuffer<B, D>> for SubmitSyncBuilderLayer<I>
     where I: AddCommand<cmd::CmdUpdateBuffer<B, D>, Out = O>,
-          B: Buffer + Clone + 'static
+          B: Buffer + Send + Sync + Clone + 'static
 {
     type Out = SubmitSyncBuilderLayer<O>;
 
@@ -440,8 +440,8 @@ unsafe impl<I, O, B, D> AddCommand<cmd::CmdUpdateBuffer<B, D>> for SubmitSyncBui
 /// Layer around a command buffer that handles synchronization between command buffers.
 pub struct SubmitSyncLayer<I> {
     inner: I,
-    buffers: Vec<(Box<Buffer>, bool)>,
-    images: Vec<(Box<Image>, bool)>,
+    buffers: Vec<(Box<Buffer + Send + Sync>, bool)>,
+    images: Vec<(Box<Image + Send + Sync>, bool)>,
 }
 
 unsafe impl<I> CommandBuffer for SubmitSyncLayer<I> where I: CommandBuffer {

--- a/vulkano/src/command_buffer/cmd/begin_render_pass.rs
+++ b/vulkano/src/command_buffer/cmd/begin_render_pass.rs
@@ -45,13 +45,13 @@ pub struct CmdBeginRenderPass<Rp, F> {
     framebuffer: F,
 }
 
-impl<F> CmdBeginRenderPass<Arc<RenderPassAbstract>, F>
+impl<F> CmdBeginRenderPass<Arc<RenderPassAbstract + Send + Sync>, F>
     where F: FramebufferAbstract
 {
     /// See the documentation of the `begin_render_pass` method.
     // TODO: allow setting more parameters
     pub fn new<C>(framebuffer: F, secondary: bool, clear_values: C)
-                  -> CmdBeginRenderPass<Arc<RenderPassAbstract>, F>
+                  -> CmdBeginRenderPass<Arc<RenderPassAbstract + Send + Sync>, F>
         where F: RenderPassDescClearValues<C>
     {
         let raw_render_pass = RenderPassAbstract::inner(&framebuffer).internal_object();

--- a/vulkano/src/framebuffer/attachments_list.rs
+++ b/vulkano/src/framebuffer/attachments_list.rs
@@ -54,7 +54,7 @@ unsafe impl AttachmentsList for () {
     }
 }
 
-unsafe impl AttachmentsList for Vec<Arc<ImageView>> {
+unsafe impl AttachmentsList for Vec<Arc<ImageView + Send + Sync>> {
     #[inline]
     fn raw_image_view_handles(&self) -> Vec<&UnsafeImageView> {
         self.iter().map(|img| img.inner()).collect()

--- a/vulkano/src/framebuffer/desc.rs
+++ b/vulkano/src/framebuffer/desc.rs
@@ -45,7 +45,7 @@ use vk;
 ///   `build_render_pass` must build a render pass from the description and not a different one.
 ///
 pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
-                                 RenderPassDescAttachmentsList<Vec<Arc<ImageView>>>
+                                 RenderPassDescAttachmentsList<Vec<Arc<ImageView + Send + Sync>>>
 {
     /// Returns the number of attachments of the render pass.
     fn num_attachments(&self) -> usize;

--- a/vulkano/src/framebuffer/empty.rs
+++ b/vulkano/src/framebuffer/empty.rs
@@ -143,9 +143,9 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 }
 
-unsafe impl RenderPassDescAttachmentsList<Vec<Arc<ImageView>>> for EmptySinglePassRenderPassDesc {
+unsafe impl RenderPassDescAttachmentsList<Vec<Arc<ImageView + Send + Sync>>> for EmptySinglePassRenderPassDesc {
     #[inline]
-    fn check_attachments_list(&self, list: Vec<Arc<ImageView>>) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+    fn check_attachments_list(&self, list: Vec<Arc<ImageView + Send + Sync>>) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
         if list.is_empty() {
             Ok(Box::new(()) as Box<_>)
         } else {
@@ -156,7 +156,7 @@ unsafe impl RenderPassDescAttachmentsList<Vec<Arc<ImageView>>> for EmptySinglePa
 
 unsafe impl RenderPassDescAttachmentsList<()> for EmptySinglePassRenderPassDesc {
     #[inline]
-    fn check_attachments_list(&self, list: ()) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+    fn check_attachments_list(&self, list: ()) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
         Ok(Box::new(()) as Box<_>)
     }
 }

--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -157,8 +157,8 @@ macro_rules! ordered_passes_renderpass {
                 }
             }
 
-            unsafe impl RenderPassDescAttachmentsList<Vec<Arc<ImageView>>> for CustomRenderPassDesc {
-                fn check_attachments_list(&self, list: Vec<Arc<ImageView>>) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+            unsafe impl RenderPassDescAttachmentsList<Vec<Arc<ImageView + Send + Sync>>> for CustomRenderPassDesc {
+                fn check_attachments_list(&self, list: Vec<Arc<ImageView + Send + Sync>>) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
                     // FIXME: correct safety checks
                     assert_eq!(list.len(), self.num_attachments());
                     Ok(Box::new(list) as Box<_>)
@@ -387,11 +387,11 @@ macro_rules! ordered_passes_renderpass {
 
     ([] __impl_attachments__ [$prev:ident] [$($prev_params:ident),*] [] [$($params:ident),*]) => {
         unsafe impl<$($prev_params),*> RenderPassDescAttachmentsList<$prev<$($prev_params),*>> for CustomRenderPassDesc
-            where $($prev_params: ImageView + 'static),*
+            where $($prev_params: ImageView + Send + Sync + 'static),*
         {
             //type List = ($($prev_params,)*);
 
-            fn check_attachments_list(&self, attachments: $prev<$($prev_params,)*>) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+            fn check_attachments_list(&self, attachments: $prev<$($prev_params,)*>) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
                 Ok(Box::new(try!(attachments.check_attachments_list())))
                 
                 // FIXME:

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -41,7 +41,7 @@ use vk;
 /// Defines the layout of multiple subpasses.
 ///
 /// The `RenderPass` struct should always implement the `RenderPassAbstract` trait. Therefore
-/// you can turn any `Arc<RenderPass<D>>` into a `Arc<RenderPassAbstract>` if you need to.
+/// you can turn any `Arc<RenderPass<D>>` into a `Arc<RenderPassAbstract + Send + Sync>` if you need to.
 pub struct RenderPass<D> {
     // The internal Vulkan object.
     renderpass: vk::RenderPass,
@@ -369,7 +369,7 @@ unsafe impl<A, D> RenderPassDescAttachmentsList<A> for RenderPass<D>
     where D: RenderPassDescAttachmentsList<A>
 {
     #[inline]
-    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
         self.desc.check_attachments_list(atch)
     }
 }

--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -21,7 +21,7 @@ use SafeDeref;
 /// Trait for objects that contain a Vulkan framebuffer object.
 ///
 /// Any `Framebuffer` object implements this trait. You can therefore turn a `Arc<Framebuffer<_>>`
-/// into a `Arc<FramebufferAbstract>` for easier storage.
+/// into a `Arc<FramebufferAbstract + Send + Sync>` for easier storage.
 pub unsafe trait FramebufferAbstract: RenderPassAbstract {
     /// Returns an opaque struct that represents the framebuffer's internals.
     fn inner(&self) -> FramebufferSys;
@@ -63,10 +63,10 @@ unsafe impl<T> FramebufferAbstract for T where T: SafeDeref, T::Target: Framebuf
 /// Trait for objects that contain a Vulkan render pass object.
 ///
 /// Any `RenderPass` object implements this trait. You can therefore turn a `Arc<RenderPass<_>>`
-/// into a `Arc<RenderPassAbstract>` for easier storage.
+/// into a `Arc<RenderPassAbstract + Send + Sync>` for easier storage.
 ///
-/// The `Arc<RenderPassAbstract>` accepts a `Vec<ClearValue>` for clear values and a
-/// `Vec<Arc<ImageView>>` for the list of attachments.
+/// The `Arc<RenderPassAbstract + Send + Sync>` accepts a `Vec<ClearValue>` for clear values and a
+/// `Vec<Arc<ImageView + Send + Sync>>` for the list of attachments.
 ///
 /// # Example
 ///
@@ -79,8 +79,8 @@ unsafe impl<T> FramebufferAbstract for T where T: SafeDeref, T::Target: Framebuf
 /// # let device: Arc<vulkano::device::Device> = return;
 /// let render_pass = RenderPass::new(device.clone(), EmptySinglePassRenderPassDesc).unwrap();
 ///
-/// // For easier storage, turn this render pass into a `Arc<RenderPassAbstract>`.
-/// let stored_rp = Arc::new(render_pass) as Arc<RenderPassAbstract>;
+/// // For easier storage, turn this render pass into a `Arc<RenderPassAbstract + Send + Sync>`.
+/// let stored_rp = Arc::new(render_pass) as Arc<RenderPassAbstract + Send + Sync>;
 /// ```
 pub unsafe trait RenderPassAbstract: DeviceOwned + RenderPassDesc {
     /// Returns an opaque object representing the render pass' internals.
@@ -120,14 +120,14 @@ pub unsafe trait RenderPassDescAttachmentsList<A> {
     ///
     /// Checks that the attachments match the render pass, and returns a list. Returns an error if
     /// one of the attachments is wrong.
-    fn check_attachments_list(&self, A) -> Result<Box<AttachmentsList>, FramebufferCreationError>;
+    fn check_attachments_list(&self, A) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError>;
 }
 
 unsafe impl<A, T> RenderPassDescAttachmentsList<A> for T
     where T: SafeDeref, T::Target: RenderPassDescAttachmentsList<A>
 {
     #[inline]
-    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
         (**self).check_attachments_list(atch)
     }
 }

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -1089,7 +1089,7 @@ unsafe impl<A, Mv, L, Rp> RenderPassDescAttachmentsList<A> for GraphicsPipeline<
     where Rp: RenderPassDescAttachmentsList<A>
 {
     #[inline]
-    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList>, FramebufferCreationError> {
+    fn check_attachments_list(&self, atch: A) -> Result<Box<AttachmentsList + Send + Sync>, FramebufferCreationError> {
         self.render_pass.check_attachments_list(atch)
     }
 }
@@ -1124,13 +1124,13 @@ impl Drop for Inner {
 
 /// Trait implemented on objects that reference a graphics pipeline. Can be made into a trait
 /// object.
-pub unsafe trait GraphicsPipelineAbstract: PipelineLayoutAbstract + RenderPassAbstract + VertexSource<Vec<Arc<Buffer>>> {
+pub unsafe trait GraphicsPipelineAbstract: PipelineLayoutAbstract + RenderPassAbstract + VertexSource<Vec<Arc<Buffer + Send + Sync>>> {
     /// Returns an opaque object that represents the inside of the graphics pipeline.
     fn inner(&self) -> GraphicsPipelineSys;
 }
 
 unsafe impl<Mv, L, Rp> GraphicsPipelineAbstract for GraphicsPipeline<Mv, L, Rp>
-    where L: PipelineLayoutAbstract, Rp: RenderPassAbstract, Mv: VertexSource<Vec<Arc<Buffer>>>
+    where L: PipelineLayoutAbstract, Rp: RenderPassAbstract, Mv: VertexSource<Vec<Arc<Buffer + Send + Sync>>>
 {
     #[inline]
     fn inner(&self) -> GraphicsPipelineSys {

--- a/vulkano/src/pipeline/vertex.rs
+++ b/vulkano/src/pipeline/vertex.rs
@@ -165,7 +165,7 @@ pub struct AttributeInfo {
 }
 
 /// Trait for types that describe the definition of the vertex input used by a graphics pipeline.
-pub unsafe trait VertexDefinition<I>: VertexSource<Vec<Arc<Buffer>>> {
+pub unsafe trait VertexDefinition<I>: VertexSource<Vec<Arc<Buffer + Send + Sync>>> {
     /// Iterator that returns the offset, the stride (in bytes) and input rate of each buffer.
     type BuffersIter: ExactSizeIterator<Item = (u32, usize, InputRate)>;
     /// Iterator that returns the attribute location, buffer id, and infos.
@@ -299,11 +299,11 @@ unsafe impl<T, I> VertexDefinition<I> for SingleBufferDefinition<T>
     }
 }
 
-unsafe impl<V> VertexSource<Vec<Arc<Buffer>>> for SingleBufferDefinition<V>
+unsafe impl<V> VertexSource<Vec<Arc<Buffer + Send + Sync>>> for SingleBufferDefinition<V>
     where V: Vertex
 {
     #[inline]
-    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer>>) -> (Vec<BufferInner<'l>>, usize, usize) {
+    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer + Send + Sync>>) -> (Vec<BufferInner<'l>>, usize, usize) {
         // FIXME: safety
         assert_eq!(source.len(), 1);
         let len = source[0].size() / mem::size_of::<V>();
@@ -381,11 +381,11 @@ unsafe impl<T, U, I> VertexDefinition<I> for TwoBuffersDefinition<T, U>
     }
 }
 
-unsafe impl<T, U> VertexSource<Vec<Arc<Buffer>>> for TwoBuffersDefinition<T, U>
+unsafe impl<T, U> VertexSource<Vec<Arc<Buffer + Send + Sync>>> for TwoBuffersDefinition<T, U>
     where T: Vertex, U: Vertex
 {
     #[inline]
-    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer>>) -> (Vec<BufferInner<'l>>, usize, usize) {
+    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer + Send + Sync>>) -> (Vec<BufferInner<'l>>, usize, usize) {
         unimplemented!()        // FIXME: implement
     }
 }
@@ -462,11 +462,11 @@ unsafe impl<T, U, I> VertexDefinition<I> for OneVertexOneInstanceDefinition<T, U
     }
 }
 
-unsafe impl<T, U> VertexSource<Vec<Arc<Buffer>>> for OneVertexOneInstanceDefinition<T, U>
+unsafe impl<T, U> VertexSource<Vec<Arc<Buffer + Send + Sync>>> for OneVertexOneInstanceDefinition<T, U>
     where T: Vertex, U: Vertex
 {
     #[inline]
-    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer>>) -> (Vec<BufferInner<'l>>, usize, usize) {
+    fn decode<'l>(&self, source: &'l Vec<Arc<Buffer + Send + Sync>>) -> (Vec<BufferInner<'l>>, usize, usize) {
         unimplemented!()        // FIXME: implement
     }
 }


### PR DESCRIPTION
EDIT: "Everywhere" in fact only means "In `Box<Trait>` and `Arc<Trait>`".