### PR TITLE
khr_physical_device_properties_2

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -1108,6 +1108,7 @@ pub struct FormatProperties {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct Extent3D {
     pub width: u32,
     pub height: u32,
@@ -1256,6 +1257,7 @@ pub struct PhysicalDeviceProperties {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct QueueFamilyProperties {
     pub queueFlags: QueueFlags,
     pub queueCount: u32,
@@ -2450,6 +2452,7 @@ pub struct PhysicalDeviceImageFormatInfo2KHR {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct QueueFamilyProperties2KHR {
     pub sType: StructureType,
     pub pNext: *const c_void,

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -203,6 +203,7 @@ instance_extensions! {
     ext_debug_report => b"VK_EXT_debug_report",
     nn_vi_surface => b"VK_NN_vi_surface",
     ext_swapchain_colorspace => b"VK_EXT_swapchain_colorspace",
+    khr_get_physical_device_properties2 => b"VK_KHR_get_physical_device_properties2",
 }
 
 device_extensions! {


### PR DESCRIPTION
There are still some places left in vulkano, where the old functions get called unconditionally.
One example is the Image initialization where we never call `vkGetPhysicalDeviceFormatProperties2KHR`. These can be fixed later and are not included in this PR.