### PR TITLE
fix teapot example

### DIFF
--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -19,6 +19,7 @@ extern crate vulkano_win;
 use vulkano_win::VkSurfaceBuild;
 use vulkano::command_buffer::CommandBufferBuilder;
 use vulkano::sync::GpuFuture;
+use vulkano::image::IntoImageView;
 
 use std::sync::Arc;
 
@@ -67,7 +68,7 @@ fn main() {
     };
 
 
-    let depth_buffer = vulkano::image::attachment::AttachmentImage::transient(&device, images[0].dimensions(), vulkano::format::D16Unorm).unwrap();
+    let depth_buffer = vulkano::image::attachment::AttachmentImage::transient(&device, images[0].dimensions(), vulkano::format::D16Unorm).unwrap().into_image_view();
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
                                 ::from_iter(&device, &vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())

--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -63,6 +63,7 @@ macro_rules! ordered_passes_renderpass {
 
         mod scope {
             #![allow(non_camel_case_types)]
+            #![allow(non_snake_case)]
 
             use std::sync::Arc;
             use $crate::format::ClearValue;


### PR DESCRIPTION
The new `IntoImageView` design of `AttachmentImage` made the teapot example unworkable. This PR fixes it.

It also fixes a snake_case warning introduced by `ordered_passes_renderpass!`.