### PR TITLE
Adding a command to a builder can now return an error

### DIFF
--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -180,10 +180,10 @@ fn main() {
             .begin_render_pass(
                 framebuffers[image_num].clone(), false,
                 renderpass.desc().start_clear_values()
-                    .color([0.0, 0.0, 1.0, 1.0]))
+                    .color([0.0, 0.0, 1.0, 1.0])).unwrap()
             .draw(pipeline.clone(), vulkano::command_buffer::DynamicState::none(), vertex_buffer.clone(),
-                  set.clone(), ())
-            .end_render_pass()
+                  set.clone(), ()).unwrap()
+            .end_render_pass().unwrap()
             .build().unwrap();
 
         let future = future

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -184,12 +184,12 @@ fn main() {
             .begin_render_pass(
                 framebuffers[image_num].clone(), false,
                 renderpass.desc().start_clear_values()
-                    .color([0.0, 0.0, 1.0, 1.0]).depth((1f32)))
+                    .color([0.0, 0.0, 1.0, 1.0]).depth((1f32))).unwrap()
             .draw_indexed(
                 pipeline.clone(), vulkano::command_buffer::DynamicState::none(),
                 (vertex_buffer.clone(), normals_buffer.clone()), 
-                index_buffer.clone(), set.clone(), ())
-            .end_render_pass()
+                index_buffer.clone(), set.clone(), ()).unwrap()
+            .end_render_pass().unwrap()
             .build().unwrap();
         
         let future = future

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -384,17 +384,20 @@ fn main() {
             // only the attachments that use `load: Clear` appear in the list.
             .begin_render_pass(framebuffers[image_num].clone(), false,
                                render_pass.desc().start_clear_values().color([0.0, 0.0, 1.0, 1.0]))
+            .unwrap()
 
             // We are now inside the first subpass of the render pass. We add a draw command.
             //
             // The last two parameters contain the list of resources to pass to the shaders.
             // Since we used an `EmptyPipeline` object, the objects have to be `()`.
             .draw(pipeline.clone(), DynamicState::none(), vertex_buffer.clone(), (), ())
+            .unwrap()
 
             // We leave the render pass by calling `draw_end`. Note that if we had multiple
             // subpasses we could have called `next_inline` (or `next_secondary`) to jump to the
             // next subpass.
             .end_render_pass()
+            .unwrap()
 
             // Finish building the command buffer by calling `build`.
             .build().unwrap();

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -16,6 +16,7 @@ use command_buffer::commands_raw;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::CommandBufferBuild;
 use command_buffer::cb::UnsafeCommandBuffer;
+use command_buffer::CommandAddError;
 use command_buffer::CommandBuffer;
 use command_buffer::CommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -142,10 +143,10 @@ macro_rules! pass_through {
             type Out = AutoCommandBufferBuilder<P>;
 
             #[inline]
-            fn add(self, command: $cmd) -> Self::Out {
-                AutoCommandBufferBuilder {
-                    inner: self.inner.add(command),
-                }
+            fn add(self, command: $cmd) -> Result<Self::Out, CommandAddError> {
+                Ok(AutoCommandBufferBuilder {
+                    inner: self.inner.add(command)?,
+                })
             }
         }
     }

--- a/vulkano/src/command_buffer/builder.rs
+++ b/vulkano/src/command_buffer/builder.rs
@@ -7,6 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::error;
+use std::fmt;
 use std::sync::Arc;
 
 use buffer::Buffer;
@@ -42,33 +44,45 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     /// > this function only for zeroing the content of a buffer by passing `0` for the data.
     // TODO: not safe because of signalling NaNs
     #[inline]
-    fn fill_buffer<B, O>(self, buffer: B, data: u32) -> Result<O, commands_raw::CmdFillBufferError>
+    fn fill_buffer<B, O>(self, buffer: B, data: u32) -> Result<O, CommandBufferBuilderError<commands_raw::CmdFillBufferError>>
         where Self: Sized + AddCommand<commands_raw::CmdFillBuffer<B::Access>, Out = O>,
               B: Buffer
     {
-        let cmd = commands_raw::CmdFillBuffer::new(buffer.access(), data)?;
-        Ok(self.add(cmd))
+        let cmd = match commands_raw::CmdFillBuffer::new(buffer.access(), data) {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Adds a command that writes data to a buffer.
     #[inline]
-    fn update_buffer<B, D, O>(self, buffer: B, data: D) -> Result<O, commands_raw::CmdUpdateBufferError>
+    fn update_buffer<B, D, O>(self, buffer: B, data: D) -> Result<O, CommandBufferBuilderError<commands_raw::CmdUpdateBufferError>>
         where Self: Sized + AddCommand<commands_raw::CmdUpdateBuffer<B::Access, D>, Out = O>,
               B: Buffer
     {
-        let cmd = commands_raw::CmdUpdateBuffer::new(buffer.access(), data)?;
-        Ok(self.add(cmd))
+        let cmd = match commands_raw::CmdUpdateBuffer::new(buffer.access(), data) {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Adds a command that copies from a buffer to another.
     #[inline]
-    fn copy_buffer<S, D, O>(self, src: S, dest: D) -> Result<O, commands_raw::CmdCopyBufferError>
+    fn copy_buffer<S, D, O>(self, src: S, dest: D) -> Result<O, CommandBufferBuilderError<commands_raw::CmdCopyBufferError>>
         where Self: Sized + AddCommand<commands_raw::CmdCopyBuffer<S::Access, D::Access>, Out = O>,
               S: Buffer,
               D: Buffer
     {
-        let cmd = commands_raw::CmdCopyBuffer::new(src.access(), dest.access())?;
-        Ok(self.add(cmd))
+        let cmd = match commands_raw::CmdCopyBuffer::new(src.access(), dest.access()) {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Adds a command that copies the content of a buffer to an image.
@@ -84,26 +98,35 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     // TODO: not safe because of signalling NaNs
     #[inline]
     fn copy_buffer_to_image<B, I, O>(self, buffer: B, image: I)
-                                     -> Result<O, commands_raw::CmdCopyBufferToImageError>
+                                     -> Result<O, CommandBufferBuilderError<commands_raw::CmdCopyBufferToImageError>>
         where Self: Sized + AddCommand<commands_raw::CmdCopyBufferToImage<B::Access, I::Access>, Out = O>,
               B: Buffer, I: Image
     {
-        let cmd = commands_raw::CmdCopyBufferToImage::new(buffer.access(), image.access())?;
-        Ok(self.add(cmd))
+        let cmd = match commands_raw::CmdCopyBufferToImage::new(buffer.access(), image.access()) {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Same as `copy_buffer_to_image` but lets you specify a range for the destination image.
     #[inline]
     fn copy_buffer_to_image_dimensions<B, I, O>(self, buffer: B, image: I, offset: [u32; 3],
                                                 size: [u32; 3], first_layer: u32, num_layers: u32,
-                                                mipmap: u32) -> Result<O, commands_raw::CmdCopyBufferToImageError>
+                                                mipmap: u32) -> Result<O, CommandBufferBuilderError<commands_raw::CmdCopyBufferToImageError>>
         where Self: Sized + AddCommand<commands_raw::CmdCopyBufferToImage<B::Access, I::Access>, Out = O>,
               B: Buffer, I: Image
     {
-        let cmd = commands_raw::CmdCopyBufferToImage::with_dimensions(buffer.access(),
-                                                             image.access(), offset, size,
-                                                             first_layer, num_layers, mipmap)?;
-        Ok(self.add(cmd))
+        let cmd = match commands_raw::CmdCopyBufferToImage::with_dimensions(buffer.access(),
+                                                                            image.access(), offset, size,
+                                                                            first_layer, num_layers, mipmap)
+        {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Adds a command that starts a render pass.
@@ -115,7 +138,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     /// You must call this before you can add draw commands.
     #[inline]
     fn begin_render_pass<F, C, O>(self, framebuffer: F, secondary: bool, clear_values: C)
-                                  -> O
+                                  -> Result<O, CommandAddError>
         where Self: Sized + AddCommand<commands_raw::CmdBeginRenderPass<Arc<RenderPassAbstract + Send + Sync>, F>, Out = O>,
               F: FramebufferAbstract + RenderPassDescClearValues<C>
     {
@@ -125,7 +148,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
 
     /// Adds a command that jumps to the next subpass of the current render pass.
     #[inline]
-    fn next_subpass<O>(self, secondary: bool) -> O
+    fn next_subpass<O>(self, secondary: bool) -> Result<O, CommandAddError>
         where Self: Sized + AddCommand<commands_raw::CmdNextSubpass, Out = O>
     {
         let cmd = commands_raw::CmdNextSubpass::new(secondary);
@@ -137,7 +160,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     /// This must be called after you went through all the subpasses and before you can build
     /// the command buffer or add further commands.
     #[inline]
-    fn end_render_pass<O>(self) -> O
+    fn end_render_pass<O>(self) -> Result<O, CommandAddError>
         where Self: Sized + AddCommand<commands_raw::CmdEndRenderPass, Out = O>
     {
         let cmd = commands_raw::CmdEndRenderPass::new();
@@ -149,7 +172,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     /// Can only be used from inside a render pass.
     #[inline]
     fn draw<P, S, Pc, V, O>(self, pipeline: P, dynamic: DynamicState, vertices: V, sets: S,
-                            push_constants: Pc) -> O
+                            push_constants: Pc) -> Result<O, CommandAddError>
         where Self: Sized + AddCommand<commands_extra::CmdDraw<V, P, S, Pc>, Out = O>,
               S: DescriptorSetsCollection,
               P: VertexSource<V> + GraphicsPipelineAbstract + Clone
@@ -163,7 +186,7 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     /// Can only be used from inside a render pass.
     #[inline]
     fn draw_indexed<P, S, Pc, V, Ib, I, O>(self, pipeline: P, dynamic: DynamicState,
-        vertices: V, index_buffer: Ib, sets: S, push_constants: Pc) -> O
+        vertices: V, index_buffer: Ib, sets: S, push_constants: Pc) -> Result<O, CommandAddError>
         where Self: Sized + AddCommand<commands_extra::CmdDrawIndexed<V, Ib::Access, P, S, Pc>, Out = O>,
               S: DescriptorSetsCollection,
               P: VertexSource<V> + GraphicsPipelineAbstract + Clone,
@@ -178,13 +201,17 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
 
     /// Executes a compute shader.
     fn dispatch<P, S, Pc, O>(self, dimensions: [u32; 3], pipeline: P, sets: S, push_constants: Pc)
-                             -> Result<O, commands_extra::CmdDispatchError>
+                             -> Result<O, CommandBufferBuilderError<commands_extra::CmdDispatchError>>
         where Self: Sized + AddCommand<commands_extra::CmdDispatch<P, S, Pc>, Out = O>,
               S: DescriptorSetsCollection,
               P: Clone + ComputePipelineAbstract,
     {
-        let cmd = try!(commands_extra::CmdDispatch::new(dimensions, pipeline, sets, push_constants));
-        Ok(self.add(cmd))
+        let cmd = match commands_extra::CmdDispatch::new(dimensions, pipeline, sets, push_constants) {
+            Ok(cmd) => cmd,
+            Err(err) => return Err(CommandBufferBuilderError::CommandBuildError(err)),
+        };
+
+        Ok(self.add(cmd)?)
     }
 
     /// Builds the actual command buffer.
@@ -206,11 +233,101 @@ pub unsafe trait CommandBufferBuilder: DeviceOwned {
     fn supports_compute(&self) -> bool;
 }
 
-pub unsafe trait CommandBufferBuilderBuffered {
-    /// Adds a pipeline barrier to the underlying command buffer and bypasses the flushing
-    /// mechanism.
-    fn add_non_buffered_pipeline_barrier(&mut self, cmd: &commands_raw::CmdPipelineBarrier);
+/// Error that can happen when adding a command to a command buffer builder.
+#[derive(Debug, Copy, Clone)]
+pub enum CommandBufferBuilderError<E> {
+    /// Error while creating the command.
+    CommandBuildError(E),
 
-    /// Flushes all the commands that haven't been flushed to the inner builder.
-    fn flush(&mut self);
+    /// Error while adding the command to the builder.
+    CommandAddError(CommandAddError),
+}
+
+impl<E> From<CommandAddError> for CommandBufferBuilderError<E> {
+    #[inline]
+    fn from(err: CommandAddError) -> CommandBufferBuilderError<E> {
+        CommandBufferBuilderError::CommandAddError(err)
+    }
+}
+
+impl<E> error::Error for CommandBufferBuilderError<E> where E: error::Error {
+    #[inline]
+    fn description(&self) -> &str {
+        match *self {
+            CommandBufferBuilderError::CommandBuildError(_) => {
+                "error while creating a command to add to a builder"
+            },
+            CommandBufferBuilderError::CommandAddError(_) => {
+                "error while adding a command to the builder"
+            },
+        }
+    }
+
+    #[inline]
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            CommandBufferBuilderError::CommandBuildError(ref err) => {
+                Some(err)
+            },
+            CommandBufferBuilderError::CommandAddError(ref err) => {
+                Some(err)
+            },
+        }
+    }
+}
+
+impl<E> fmt::Display for CommandBufferBuilderError<E> where E: error::Error {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", error::Error::description(self))
+    }
+}
+
+/// Error that can happen when adding a command to a command buffer builder.
+#[derive(Debug, Copy, Clone)]
+pub enum CommandAddError {
+    /// This command is forbidden when inside a render pass.
+    ForbiddenInsideRenderPass,
+
+    /// This command is forbidden when outside of a render pass.
+    ForbiddenOutsideRenderPass,
+
+    /// This command is forbidden in a secondary command buffer.
+    ForbiddenInSecondaryCommandBuffer,
+
+    /// The queue family doesn't support graphics operations.
+    GraphicsOperationsNotSupported,
+
+    /// The queue family doesn't support compute operations.
+    ComputeOperationsNotSupported,
+}
+
+impl error::Error for CommandAddError {
+    #[inline]
+    fn description(&self) -> &str {
+        match *self {
+            CommandAddError::ForbiddenInsideRenderPass => {
+                "this command is forbidden when inside a render pass"
+            },
+            CommandAddError::ForbiddenOutsideRenderPass => {
+                "this command is forbidden when outside of a render pass"
+            },
+            CommandAddError::ForbiddenInSecondaryCommandBuffer => {
+                "this command is forbidden in a secondary command buffer"
+            },
+            CommandAddError::GraphicsOperationsNotSupported => {
+                "the queue family doesn't support graphics operations"
+            },
+            CommandAddError::ComputeOperationsNotSupported => {
+                "the queue family doesn't support compute operations"
+            },
+        }
+    }
+}
+
+impl fmt::Display for CommandAddError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", error::Error::description(self))
+    }
 }

--- a/vulkano/src/command_buffer/cb/abstract_storage.rs
+++ b/vulkano/src/command_buffer/cb/abstract_storage.rs
@@ -16,6 +16,7 @@ use command_buffer::cb::AddCommand;
 use command_buffer::cb::CommandBufferBuild;
 use command_buffer::cb::UnsafeCommandBuffer;
 use command_buffer::commands_raw;
+use command_buffer::CommandAddError;
 use command_buffer::CommandBuffer;
 use command_buffer::CommandBufferBuilder;
 use device::Device;
@@ -115,15 +116,15 @@ macro_rules! pass_through {
             type Out = AbstractStorageLayer<I>;
 
             #[inline]
-            fn add(mut self, command: $cmd) -> Self::Out {
-                let new_inner = AddCommand::add(self.inner, &command);
+            fn add(mut self, command: $cmd) -> Result<Self::Out, CommandAddError> {
+                let new_inner = AddCommand::add(self.inner, &command)?;
                 // TODO: should store a lightweight version of the command
                 self.commands.push(Box::new(command) as Box<_>);
                 
-                AbstractStorageLayer {
+                Ok(AbstractStorageLayer {
                     inner: new_inner,
                     commands: self.commands,
-                }
+                })
             }
         }
     }

--- a/vulkano/src/command_buffer/cb/auto_barriers.rs
+++ b/vulkano/src/command_buffer/cb/auto_barriers.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::CommandBufferBuild;
+use command_buffer::CommandAddError;
 use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use device::Device;
@@ -84,10 +85,10 @@ macro_rules! pass_through {
             type Out = AutoPipelineBarriersLayer<O>;
 
             #[inline]
-            fn add(self, command: $cmd) -> Self::Out {
-                AutoPipelineBarriersLayer {
-                    inner: AddCommand::add(self.inner, command),
-                }
+            fn add(self, command: $cmd) -> Result<Self::Out, CommandAddError> {
+                Ok(AutoPipelineBarriersLayer {
+                    inner: AddCommand::add(self.inner, command)?,
+                })
             }
         }
     }

--- a/vulkano/src/command_buffer/cb/device_check.rs
+++ b/vulkano/src/command_buffer/cb/device_check.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::CommandBufferBuild;
+use command_buffer::CommandAddError;
 use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use device::Device;
@@ -81,14 +82,14 @@ macro_rules! pass_through {
             type Out = DeviceCheckLayer<O>;
 
             #[inline]
-            fn add(self, command: $cmd) -> Self::Out {
+            fn add(self, command: $cmd) -> Result<Self::Out, CommandAddError> {
                 let inner_device = self.inner.device().internal_object();
                 let cmd_device = command.device().internal_object();
                 assert_eq!(inner_device, cmd_device);
 
-                DeviceCheckLayer {
-                    inner: self.inner.add(command),
-                }
+                Ok(DeviceCheckLayer {
+                    inner: self.inner.add(command)?,
+                })
             }
         }
     );
@@ -100,10 +101,10 @@ macro_rules! pass_through {
             type Out = DeviceCheckLayer<O>;
 
             #[inline]
-            fn add(self, command: $cmd) -> Self::Out {
-                DeviceCheckLayer {
-                    inner: self.inner.add(command),
-                }
+            fn add(self, command: $cmd) -> Result<Self::Out, CommandAddError> {
+                Ok(DeviceCheckLayer {
+                    inner: self.inner.add(command)?,
+                })
             }
         }
     );

--- a/vulkano/src/command_buffer/cb/submit_sync.rs
+++ b/vulkano/src/command_buffer/cb/submit_sync.rs
@@ -14,6 +14,7 @@ use buffer::BufferAccess;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::CommandBufferBuild;
 use command_buffer::cb::UnsafeCommandBuffer;
+use command_buffer::CommandAddError;
 use command_buffer::CommandBuffer;
 use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
@@ -126,12 +127,12 @@ macro_rules! pass_through {
             type Out = SubmitSyncBuilderLayer<O>;
 
             #[inline]
-            fn add(self, command: $cmd) -> Self::Out {
-                SubmitSyncBuilderLayer {
-                    inner: AddCommand::add(self.inner, command),
+            fn add(self, command: $cmd) -> Result<Self::Out, CommandAddError> {
+                Ok(SubmitSyncBuilderLayer {
+                    inner: AddCommand::add(self.inner, command)?,
                     buffers: self.buffers,
                     images: self.images,
-                }
+                })
             }
         }
     }
@@ -150,14 +151,14 @@ unsafe impl<I, O, B> AddCommand<commands_raw::CmdBindIndexBuffer<B>> for SubmitS
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdBindIndexBuffer<B>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdBindIndexBuffer<B>) -> Result<Self::Out, CommandAddError> {
         self.add_buffer(command.buffer(), false);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -167,12 +168,12 @@ unsafe impl<I, O, P> AddCommand<commands_raw::CmdBindPipeline<P>> for SubmitSync
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdBindPipeline<P>) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdBindPipeline<P>) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -184,15 +185,15 @@ unsafe impl<I, O, S, D> AddCommand<commands_raw::CmdBlitImage<S, D>> for SubmitS
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdBlitImage<S, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdBlitImage<S, D>) -> Result<Self::Out, CommandAddError> {
         self.add_image(command.source(), false);
         self.add_image(command.destination(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -202,12 +203,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdClearAttachments> for SubmitSyncBu
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdClearAttachments) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdClearAttachments) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -219,15 +220,15 @@ unsafe impl<I, O, S, D> AddCommand<commands_raw::CmdCopyBuffer<S, D>> for Submit
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdCopyBuffer<S, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdCopyBuffer<S, D>) -> Result<Self::Out, CommandAddError> {
         self.add_buffer(command.source(), false);
         self.add_buffer(command.destination(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -239,15 +240,15 @@ unsafe impl<I, O, S, D> AddCommand<commands_raw::CmdCopyBufferToImage<S, D>> for
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdCopyBufferToImage<S, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdCopyBufferToImage<S, D>) -> Result<Self::Out, CommandAddError> {
         self.add_buffer(command.source(), false);
         self.add_image(command.destination(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -259,15 +260,15 @@ unsafe impl<I, O, S, D> AddCommand<commands_raw::CmdCopyImage<S, D>> for SubmitS
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdCopyImage<S, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdCopyImage<S, D>) -> Result<Self::Out, CommandAddError> {
         self.add_image(command.source(), false);
         self.add_image(command.destination(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -277,12 +278,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdDispatchRaw> for SubmitSyncBuilder
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdDispatchRaw) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdDispatchRaw) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -292,12 +293,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdDrawRaw> for SubmitSyncBuilderLaye
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdDrawRaw) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdDrawRaw) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -307,12 +308,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdDrawIndexedRaw> for SubmitSyncBuil
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdDrawIndexedRaw) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdDrawIndexedRaw) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -322,12 +323,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdEndRenderPass> for SubmitSyncBuild
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdEndRenderPass) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdEndRenderPass) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -338,14 +339,14 @@ unsafe impl<I, O, B> AddCommand<commands_raw::CmdFillBuffer<B>> for SubmitSyncBu
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdFillBuffer<B>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdFillBuffer<B>) -> Result<Self::Out, CommandAddError> {
         self.add_buffer(command.buffer(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -355,12 +356,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdNextSubpass> for SubmitSyncBuilder
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdNextSubpass) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdNextSubpass) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -370,12 +371,12 @@ unsafe impl<I, O, Pc, Pl> AddCommand<commands_raw::CmdPushConstants<Pc, Pl>> for
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdPushConstants<Pc, Pl>) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdPushConstants<Pc, Pl>) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -387,15 +388,15 @@ unsafe impl<I, O, S, D> AddCommand<commands_raw::CmdResolveImage<S, D>> for Subm
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdResolveImage<S, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdResolveImage<S, D>) -> Result<Self::Out, CommandAddError> {
         self.add_image(command.source(), false);
         self.add_image(command.destination(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -405,12 +406,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdSetEvent> for SubmitSyncBuilderLay
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdSetEvent) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdSetEvent) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -420,12 +421,12 @@ unsafe impl<I, O> AddCommand<commands_raw::CmdSetState> for SubmitSyncBuilderLay
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(self, command: commands_raw::CmdSetState) -> Self::Out {
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+    fn add(self, command: commands_raw::CmdSetState) -> Result<Self::Out, CommandAddError> {
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 
@@ -436,14 +437,14 @@ unsafe impl<I, O, B, D> AddCommand<commands_raw::CmdUpdateBuffer<B, D>> for Subm
     type Out = SubmitSyncBuilderLayer<O>;
 
     #[inline]
-    fn add(mut self, command: commands_raw::CmdUpdateBuffer<B, D>) -> Self::Out {
+    fn add(mut self, command: commands_raw::CmdUpdateBuffer<B, D>) -> Result<Self::Out, CommandAddError> {
         self.add_buffer(command.buffer(), true);
 
-        SubmitSyncBuilderLayer {
-            inner: AddCommand::add(self.inner, command),
+        Ok(SubmitSyncBuilderLayer {
+            inner: AddCommand::add(self.inner, command)?,
             buffers: self.buffers,
             images: self.images,
-        }
+        })
     }
 }
 

--- a/vulkano/src/command_buffer/cb/traits.rs
+++ b/vulkano/src/command_buffer/cb/traits.rs
@@ -7,6 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
+
 /// Adds a command to a command buffer builder.
 pub unsafe trait AddCommand<C> {
     /// The new command buffer builder type.
@@ -14,5 +16,5 @@ pub unsafe trait AddCommand<C> {
 
     /// Adds the command. This takes ownership of the builder and returns a new builder with the
     /// command appended at the end of it.
-    fn add(self, cmd: C) -> Self::Out;
+    fn add(self, cmd: C) -> Result<Self::Out, CommandAddError>;
 }

--- a/vulkano/src/command_buffer/commands_extra/dispatch.rs
+++ b/vulkano/src/command_buffer/commands_extra/dispatch.rs
@@ -11,6 +11,7 @@ use std::error;
 use std::fmt;
 
 use command_buffer::cb::AddCommand;
+use command_buffer::CommandAddError;
 use command_buffer::commands_raw::CmdBindDescriptorSets;
 use command_buffer::commands_raw::CmdBindDescriptorSetsError;
 use command_buffer::commands_raw::CmdBindPipeline;
@@ -60,11 +61,11 @@ unsafe impl<Cb, P, S, Pc, O, O1, O2, O3> AddCommand<CmdDispatch<P, S, Pc>> for C
     type Out = O;
 
     #[inline]
-    fn add(self, command: CmdDispatch<P, S, Pc>) -> O {
-        self.add(command.push_constants)
-            .add(command.descriptor_sets)
-            .add(command.bind_pipeline)
-            .add(command.dispatch_raw)
+    fn add(self, command: CmdDispatch<P, S, Pc>) -> Result<Self::Out, CommandAddError> {
+        Ok(self.add(command.push_constants)?
+               .add(command.descriptor_sets)?
+               .add(command.bind_pipeline)?
+               .add(command.dispatch_raw)?)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_extra/dispatch_indirect.rs
+++ b/vulkano/src/command_buffer/commands_extra/dispatch_indirect.rs
@@ -19,6 +19,7 @@ use command_buffer::commands_raw::CmdBindDescriptorSetsError;
 use command_buffer::commands_raw::CmdBindPipeline;
 use command_buffer::commands_raw::CmdPushConstants;
 use command_buffer::commands_raw::CmdPushConstantsError;
+use command_buffer::CommandAddError;
 use command_buffer::DispatchIndirectCommand;
 use command_buffer::RawCommandBufferPrototype;
 use command_buffer::CommandsList;

--- a/vulkano/src/command_buffer/commands_extra/draw.rs
+++ b/vulkano/src/command_buffer/commands_extra/draw.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
 use command_buffer::DynamicState;
 use command_buffer::cb::AddCommand;
 use command_buffer::commands_raw::CmdBindDescriptorSets;
@@ -69,12 +70,12 @@ unsafe impl<Cb, V, P, S, Pc, O, O1, O2, O3, O4, O5> AddCommand<CmdDraw<V, P, S, 
     type Out = O;
 
     #[inline]
-    fn add(self, command: CmdDraw<V, P, S, Pc>) -> O {
-        self.add(command.vertex_buffers)
-            .add(command.push_constants)
-            .add(command.descriptor_sets)
-            .add(command.set_state)
-            .add(command.bind_pipeline)
-            .add(command.draw_raw)
+    fn add(self, command: CmdDraw<V, P, S, Pc>) -> Result<Self::Out, CommandAddError> {
+        Ok(self.add(command.vertex_buffers)?
+               .add(command.push_constants)?
+               .add(command.descriptor_sets)?
+               .add(command.set_state)?
+               .add(command.bind_pipeline)?
+               .add(command.draw_raw)?)
     }
 }

--- a/vulkano/src/command_buffer/commands_extra/draw_indexed.rs
+++ b/vulkano/src/command_buffer/commands_extra/draw_indexed.rs
@@ -9,6 +9,7 @@
 
 use buffer::BufferAccess;
 use buffer::TypedBuffer;
+use command_buffer::CommandAddError;
 use command_buffer::DynamicState;
 use command_buffer::cb::AddCommand;
 use command_buffer::commands_raw::CmdBindDescriptorSets;
@@ -88,13 +89,13 @@ unsafe impl<Cb, V, Ib, P, S, Pc, O, O1, O2, O3, O4, O5, O6> AddCommand<CmdDrawIn
 {
     type Out = O;
     #[inline]
-    fn add(self, command: CmdDrawIndexed<V, Ib, P, S, Pc>) -> O {
-        self.add(command.vertex_buffers)
-            .add(command.index_buffer)
-            .add(command.push_constants)
-            .add(command.descriptor_sets)
-            .add(command.set_state)
-            .add(command.bind_pipeline)
-            .add(command.draw_indexed_raw)
+    fn add(self, command: CmdDrawIndexed<V, Ib, P, S, Pc>) -> Result<Self::Out, CommandAddError> {
+        Ok(self.add(command.vertex_buffers)?
+               .add(command.index_buffer)?
+               .add(command.push_constants)?
+               .add(command.descriptor_sets)?
+               .add(command.set_state)?
+               .add(command.bind_pipeline)?
+               .add(command.draw_indexed_raw)?)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/begin_render_pass.rs
+++ b/vulkano/src/command_buffer/commands_raw/begin_render_pass.rs
@@ -12,6 +12,7 @@ use std::ops::Range;
 use std::ptr;
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -124,7 +125,7 @@ unsafe impl<'a, P, Rp, F> AddCommand<&'a CmdBeginRenderPass<Rp, F>> for UnsafeCo
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBeginRenderPass<Rp, F>) -> Self::Out {
+    fn add(self, command: &'a CmdBeginRenderPass<Rp, F>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -151,6 +152,6 @@ unsafe impl<'a, P, Rp, F> AddCommand<&'a CmdBeginRenderPass<Rp, F>> for UnsafeCo
             vk.CmdBeginRenderPass(cmd, &begin, command.contents);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/bind_descriptor_sets.rs
+++ b/vulkano/src/command_buffer/commands_raw/bind_descriptor_sets.rs
@@ -13,6 +13,7 @@ use std::ptr;
 use std::sync::Arc;
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -119,7 +120,7 @@ unsafe impl<'a, P, Pl, S> AddCommand<&'a CmdBindDescriptorSets<S, Pl>> for Unsaf
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBindDescriptorSets<S, Pl>) -> Self::Out {
+    fn add(self, command: &'a CmdBindDescriptorSets<S, Pl>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -131,7 +132,7 @@ unsafe impl<'a, P, Pl, S> AddCommand<&'a CmdBindDescriptorSets<S, Pl>> for Unsaf
             }
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/bind_index_buffer.rs
+++ b/vulkano/src/command_buffer/commands_raw/bind_index_buffer.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use buffer::BufferAccess;
 use buffer::TypedBuffer;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -89,13 +90,13 @@ unsafe impl<'a, P, B> AddCommand<&'a CmdBindIndexBuffer<B>> for UnsafeCommandBuf
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBindIndexBuffer<B>) -> Self::Out {
+    fn add(self, command: &'a CmdBindIndexBuffer<B>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
             vk.CmdBindIndexBuffer(cmd, command.raw_buffer, command.offset, command.index_type);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/bind_pipeline.rs
+++ b/vulkano/src/command_buffer/commands_raw/bind_pipeline.rs
@@ -10,6 +10,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -105,7 +106,7 @@ unsafe impl<'a, P, Pl> AddCommand<&'a CmdBindPipeline<Pl>> for UnsafeCommandBuff
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBindPipeline<Pl>) -> Self::Out {
+    fn add(self, command: &'a CmdBindPipeline<Pl>) -> Result<Self::Out, CommandAddError> {
         if command.raw_pipeline != 0 {
             unsafe {
                 let vk = self.device().pointers();
@@ -114,7 +115,7 @@ unsafe impl<'a, P, Pl> AddCommand<&'a CmdBindPipeline<Pl>> for UnsafeCommandBuff
             }
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/bind_vertex_buffers.rs
+++ b/vulkano/src/command_buffer/commands_raw/bind_vertex_buffers.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -70,7 +71,7 @@ unsafe impl<'a, P, B> AddCommand<&'a CmdBindVertexBuffers<B>> for UnsafeCommandB
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBindVertexBuffers<B>) -> Self::Out {
+    fn add(self, command: &'a CmdBindVertexBuffers<B>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -78,6 +79,6 @@ unsafe impl<'a, P, B> AddCommand<&'a CmdBindVertexBuffers<B>> for UnsafeCommandB
                                     command.raw_buffers.as_ptr(), command.offsets.as_ptr());
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/blit_image.rs
+++ b/vulkano/src/command_buffer/commands_raw/blit_image.rs
@@ -10,6 +10,7 @@
 use std::error;
 use std::fmt;
 use std::sync::Arc;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -80,7 +81,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdBlitImage<S, D>> for UnsafeCommandBuf
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdBlitImage<S, D>) -> Self::Out {
+    fn add(self, command: &'a CmdBlitImage<S, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             debug_assert!(command.source_layout == vk::IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL ||
                           command.source_layout == vk::IMAGE_LAYOUT_GENERAL);
@@ -133,7 +134,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdBlitImage<S, D>> for UnsafeCommandBuf
                             1, &region as *const _, command.filter);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/clear_attachments.rs
+++ b/vulkano/src/command_buffer/commands_raw/clear_attachments.rs
@@ -9,6 +9,7 @@
 
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -33,7 +34,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdClearAttachments> for UnsafeCommandBufferBu
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdClearAttachments) -> Self::Out {
+    fn add(self, command: &'a CmdClearAttachments) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -43,6 +44,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdClearAttachments> for UnsafeCommandBufferBu
                                    command.rects.as_ptr());
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/copy_buffer.rs
+++ b/vulkano/src/command_buffer/commands_raw/copy_buffer.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use buffer::BufferAccess;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -120,7 +121,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyBuffer<S, D>> for UnsafeCommandBu
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdCopyBuffer<S, D>) -> Self::Out {
+    fn add(self, command: &'a CmdCopyBuffer<S, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -134,7 +135,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyBuffer<S, D>> for UnsafeCommandBu
             vk.CmdCopyBuffer(cmd, command.source_raw, command.destination_raw, 1, &region);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/copy_buffer_to_image.rs
+++ b/vulkano/src/command_buffer/commands_raw/copy_buffer_to_image.rs
@@ -11,6 +11,7 @@ use std::error;
 use std::fmt;
 use std::sync::Arc;
 use buffer::BufferAccess;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -149,7 +150,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyBufferToImage<S, D>> for UnsafeCo
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdCopyBufferToImage<S, D>) -> Self::Out {
+    fn add(self, command: &'a CmdCopyBufferToImage<S, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             debug_assert!(command.destination_layout == vk::IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL ||
                           command.destination_layout == vk::IMAGE_LAYOUT_GENERAL);
@@ -182,7 +183,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyBufferToImage<S, D>> for UnsafeCo
                                     command.destination_layout, 1, &region as *const _);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/copy_image.rs
+++ b/vulkano/src/command_buffer/commands_raw/copy_image.rs
@@ -10,6 +10,7 @@
 use std::error;
 use std::fmt;
 use std::sync::Arc;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -79,7 +80,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyImage<S, D>> for UnsafeCommandBuf
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdCopyImage<S, D>) -> Self::Out {
+    fn add(self, command: &'a CmdCopyImage<S, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             debug_assert!(command.source_layout == vk::IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL ||
                           command.source_layout == vk::IMAGE_LAYOUT_GENERAL);
@@ -123,7 +124,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdCopyImage<S, D>> for UnsafeCommandBuf
                             1, &region as *const _);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/dispatch_raw.rs
+++ b/vulkano/src/command_buffer/commands_raw/dispatch_raw.rs
@@ -11,6 +11,7 @@ use std::error;
 use std::fmt;
 use std::sync::Arc;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -97,7 +98,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdDispatchRaw> for UnsafeCommandBufferBuilder
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdDispatchRaw) -> Self::Out {
+    fn add(self, command: &'a CmdDispatchRaw) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -105,7 +106,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdDispatchRaw> for UnsafeCommandBufferBuilder
                            command.dimensions[2]);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/draw_indexed_raw.rs
+++ b/vulkano/src/command_buffer/commands_raw/draw_indexed_raw.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -66,7 +67,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdDrawIndexedRaw> for UnsafeCommandBufferBuil
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdDrawIndexedRaw) -> Self::Out {
+    fn add(self, command: &'a CmdDrawIndexedRaw) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -74,6 +75,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdDrawIndexedRaw> for UnsafeCommandBufferBuil
                               command.first_index, command.vertex_offset, command.first_instance);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/draw_indirect_raw.rs
+++ b/vulkano/src/command_buffer/commands_raw/draw_indirect_raw.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 use buffer::BufferAccess;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -58,7 +59,7 @@ unsafe impl<'a, B, P> AddCommand<&'a CmdDrawIndirectRaw<B>> for UnsafeCommandBuf
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdDrawIndirectRaw<B>) -> Self::Out {
+    fn add(self, command: &'a CmdDrawIndirectRaw<B>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -66,6 +67,6 @@ unsafe impl<'a, B, P> AddCommand<&'a CmdDrawIndirectRaw<B>> for UnsafeCommandBuf
                                command.offset, command.draw_count, command.stride);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/draw_raw.rs
+++ b/vulkano/src/command_buffer/commands_raw/draw_raw.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -61,7 +62,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdDrawRaw> for UnsafeCommandBufferBuilder<P>
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdDrawRaw) -> Self::Out {
+    fn add(self, command: &'a CmdDrawRaw) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -69,6 +70,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdDrawRaw> for UnsafeCommandBufferBuilder<P>
                        command.first_instance);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/end_render_pass.rs
+++ b/vulkano/src/command_buffer/commands_raw/end_render_pass.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -32,13 +33,13 @@ unsafe impl<'a, P> AddCommand<&'a CmdEndRenderPass> for UnsafeCommandBufferBuild
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdEndRenderPass) -> Self::Out {
+    fn add(self, command: &'a CmdEndRenderPass) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
             vk.CmdEndRenderPass(cmd);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/execute.rs
+++ b/vulkano/src/command_buffer/commands_raw/execute.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -60,13 +61,13 @@ unsafe impl<'a, P, Cb> AddCommand<&'a CmdExecuteCommands<Cb>> for UnsafeCommandB
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdExecuteCommands<Cb>) -> Self::Out {
+    fn add(self, command: &'a CmdExecuteCommands<Cb>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
             vk.CmdExecuteCommands(cmd, command.raw_list.len() as u32, command.raw_list.as_ptr());
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/fill_buffer.rs
+++ b/vulkano/src/command_buffer/commands_raw/fill_buffer.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use buffer::BufferAccess;
 use buffer::BufferInner;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -87,7 +88,7 @@ unsafe impl<'a, P, B> AddCommand<&'a CmdFillBuffer<B>> for UnsafeCommandBufferBu
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdFillBuffer<B>) -> Self::Out {
+    fn add(self, command: &'a CmdFillBuffer<B>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -95,7 +96,7 @@ unsafe impl<'a, P, B> AddCommand<&'a CmdFillBuffer<B>> for UnsafeCommandBufferBu
                              command.size, command.data);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/next_subpass.rs
+++ b/vulkano/src/command_buffer/commands_raw/next_subpass.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -39,13 +40,13 @@ unsafe impl<'a, P> AddCommand<&'a CmdNextSubpass> for UnsafeCommandBufferBuilder
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdNextSubpass) -> Self::Out {
+    fn add(self, command: &'a CmdNextSubpass) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
             vk.CmdNextSubpass(cmd, command.contents);
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/pipeline_barrier.rs
+++ b/vulkano/src/command_buffer/commands_raw/pipeline_barrier.rs
@@ -15,6 +15,7 @@ use smallvec::SmallVec;
 
 use buffer::BufferAccess;
 use buffer::BufferInner;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -239,14 +240,14 @@ unsafe impl<'a, P> AddCommand<&'a CmdPipelineBarrier<'a>> for UnsafeCommandBuffe
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdPipelineBarrier<'a>) -> Self::Out {
+    fn add(self, command: &'a CmdPipelineBarrier<'a>) -> Result<Self::Out, CommandAddError> {
         // If barrier is empty, don't do anything.
         if command.src_stage_mask == 0 || command.dst_stage_mask == 0 {
             debug_assert!(command.src_stage_mask == 0 && command.dst_stage_mask == 0);
             debug_assert!(command.memory_barriers.is_empty());
             debug_assert!(command.buffer_barriers.is_empty());
             debug_assert!(command.image_barriers.is_empty());
-            return self;
+            return Ok(self);
         }
 
         unsafe {
@@ -262,6 +263,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdPipelineBarrier<'a>> for UnsafeCommandBuffe
                                   command.image_barriers.as_ptr());
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/push_constants.rs
+++ b/vulkano/src/command_buffer/commands_raw/push_constants.rs
@@ -11,6 +11,7 @@ use std::error;
 use std::fmt;
 use std::sync::Arc;
 
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -70,7 +71,7 @@ unsafe impl<'a, P, Pc, Pl> AddCommand<&'a CmdPushConstants<Pc, Pl>> for UnsafeCo
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdPushConstants<Pc, Pl>) -> Self::Out {
+    fn add(self, command: &'a CmdPushConstants<Pc, Pl>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -92,7 +93,7 @@ unsafe impl<'a, P, Pc, Pl> AddCommand<&'a CmdPushConstants<Pc, Pl>> for UnsafeCo
             }
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/resolve_image.rs
+++ b/vulkano/src/command_buffer/commands_raw/resolve_image.rs
@@ -10,6 +10,7 @@
 use std::error;
 use std::fmt;
 use std::sync::Arc;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -79,7 +80,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdResolveImage<S, D>> for UnsafeCommand
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdResolveImage<S, D>) -> Self::Out {
+    fn add(self, command: &'a CmdResolveImage<S, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             debug_assert!(command.source_layout == vk::IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL ||
                           command.source_layout == vk::IMAGE_LAYOUT_GENERAL);
@@ -123,7 +124,7 @@ unsafe impl<'a, P, S, D> AddCommand<&'a CmdResolveImage<S, D>> for UnsafeCommand
                                1, &region as *const _);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/set_event.rs
+++ b/vulkano/src/command_buffer/commands_raw/set_event.rs
@@ -8,6 +8,7 @@
 // according to those terms.
 
 use std::sync::Arc;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -44,7 +45,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdSetEvent> for UnsafeCommandBufferBuilder<P>
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdSetEvent) -> Self::Out {
+    fn add(self, command: &'a CmdSetEvent) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -55,6 +56,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdSetEvent> for UnsafeCommandBufferBuilder<P>
             }
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/set_state.rs
+++ b/vulkano/src/command_buffer/commands_raw/set_state.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 use smallvec::SmallVec;
 
+use command_buffer::CommandAddError;
 use command_buffer::DynamicState;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
@@ -73,7 +74,7 @@ unsafe impl<'a, P> AddCommand<&'a CmdSetState> for UnsafeCommandBufferBuilder<P>
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdSetState) -> Self::Out {
+    fn add(self, command: &'a CmdSetState) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let vk = self.device().pointers();
             let cmd = self.internal_object();
@@ -93,6 +94,6 @@ unsafe impl<'a, P> AddCommand<&'a CmdSetState> for UnsafeCommandBufferBuilder<P>
             }
         }
 
-        self
+        Ok(self)
     }
 }

--- a/vulkano/src/command_buffer/commands_raw/update_buffer.rs
+++ b/vulkano/src/command_buffer/commands_raw/update_buffer.rs
@@ -15,6 +15,7 @@ use std::ptr;
 
 use buffer::BufferAccess;
 use buffer::BufferInner;
+use command_buffer::CommandAddError;
 use command_buffer::cb::AddCommand;
 use command_buffer::cb::UnsafeCommandBufferBuilder;
 use command_buffer::pool::CommandPool;
@@ -109,7 +110,7 @@ unsafe impl<'a, P, B, D> AddCommand<&'a CmdUpdateBuffer<B, D>> for UnsafeCommand
     type Out = UnsafeCommandBufferBuilder<P>;
 
     #[inline]
-    fn add(self, command: &'a CmdUpdateBuffer<B, D>) -> Self::Out {
+    fn add(self, command: &'a CmdUpdateBuffer<B, D>) -> Result<Self::Out, CommandAddError> {
         unsafe {
             let data = if command.data_ptr.is_null() {
                 &command.data as *const D as *const _
@@ -122,7 +123,7 @@ unsafe impl<'a, P, B, D> AddCommand<&'a CmdUpdateBuffer<B, D>> for UnsafeCommand
             vk.CmdUpdateBuffer(cmd, command.buffer_handle, command.offset, command.size, data);
         }
 
-        self
+        Ok(self)
     }
 }
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -75,8 +75,8 @@
 //! information.
 
 pub use self::auto::AutoCommandBufferBuilder;
+pub use self::builder::CommandAddError;
 pub use self::builder::CommandBufferBuilder;
-pub use self::builder::CommandBufferBuilderBuffered;
 pub use self::traits::CommandBuffer;
 pub use self::traits::CommandBufferBuild;
 pub use self::traits::CommandBufferExecFuture;


### PR DESCRIPTION
The `add` function now returns a `Result<Self::Out, CommandAddError>` instead of `Self::Out`.

I initially wanted to return `Result<Self::Out, (Self, CommandAddError)>` instead, so that the user can get back the command buffer builder if adding the command fails, but it makes the code much more complex and dirtier.
