### PR TITLE
Fix texture arrays not working

### DIFF
--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -254,7 +254,8 @@ impl DescriptorImageDesc {
                 match (my_max, other_max) {
                     (Some(m), Some(o)) => if m < o { return false; },
                     (Some(_), None) => (),
-                    (None, _) => return false,
+                    (None, Some(_)) => return false,
+                    (None, None) => (),     // TODO: is this correct?
                 };
             },
             _ => return false


### PR DESCRIPTION
Before this PR descriptors that contain texture arrays are always incompatible with themselves.
Not sure what the right fix is, though. There's definitely a design-related issue here.