### PR TITLE
Add PipelineLayoutNotSupersetError

### DIFF
--- a/vulkano/src/descriptor/pipeline_layout/mod.rs
+++ b/vulkano/src/descriptor/pipeline_layout/mod.rs
@@ -58,6 +58,7 @@ pub use self::traits::PipelineLayoutDesc;
 pub use self::traits::PipelineLayoutDescNames;
 pub use self::traits::PipelineLayoutDescPcRange;
 pub use self::traits::PipelineLayoutSuperset;
+pub use self::traits::PipelineLayoutNotSupersetError;
 pub use self::traits::PipelineLayoutSetsCompatible;
 pub use self::traits::PipelineLayoutPushConstantsCompatible;
 pub use self::union::PipelineLayoutDescUnion;


### PR DESCRIPTION
Proper error type when two pipeline layouts are incompatible.