### PR TITLE
Add CommandBufferBuilder::queue_family()

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -41,9 +41,6 @@ impl AutoCommandBufferBuilder<Arc<StandardCommandPool>> {
     pub fn new(device: Arc<Device>, queue_family: QueueFamily)
                -> Result<AutoCommandBufferBuilder<Arc<StandardCommandPool>>, OomError>
     {
-        let supports_graphics = queue_family.supports_graphics();
-        let supports_compute = queue_family.supports_compute();
-
         let pool = Device::standard_command_pool(&device, queue_family);
 
         let cmd = unsafe {
@@ -53,7 +50,7 @@ impl AutoCommandBufferBuilder<Arc<StandardCommandPool>> {
             let c = cb::SubmitSyncBuilderLayer::new(c);
             let c = cb::StateCacheLayer::new(c);
             let c = cb::ContextCheckLayer::new(c, false, true);
-            let c = cb::QueueTyCheckLayer::new(c, supports_graphics, supports_compute);
+            let c = cb::QueueTyCheckLayer::new(c);
             let c = cb::DeviceCheckLayer::new(c);
             c
         };
@@ -124,13 +121,8 @@ unsafe impl<P> CommandBufferBuilder for AutoCommandBufferBuilder<P>
           P: CommandPool
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/abstract_storage.rs
+++ b/vulkano/src/command_buffer/cb/abstract_storage.rs
@@ -23,6 +23,7 @@ use device::Device;
 use device::DeviceOwned;
 use device::Queue;
 use image::ImageAccess;
+use instance::QueueFamily;
 use sync::AccessFlagBits;
 use sync::GpuFuture;
 use sync::PipelineStages;
@@ -98,13 +99,8 @@ unsafe impl<I, O, E> CommandBufferBuild for AbstractStorageLayer<I>
 
 unsafe impl<I> CommandBufferBuilder for AbstractStorageLayer<I> where I: CommandBufferBuilder {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/auto_barriers.rs
+++ b/vulkano/src/command_buffer/cb/auto_barriers.rs
@@ -15,6 +15,7 @@ use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use device::Device;
 use device::DeviceOwned;
+use instance::QueueFamily;
 
 pub struct AutoPipelineBarriersLayer<I> {
     inner: I,
@@ -67,13 +68,8 @@ unsafe impl<I> CommandBufferBuilder for AutoPipelineBarriersLayer<I>
     where I: CommandBufferBuilder
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/context_check.rs
+++ b/vulkano/src/command_buffer/cb/context_check.rs
@@ -15,6 +15,7 @@ use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use device::Device;
 use device::DeviceOwned;
+use instance::QueueFamily;
 
 /// Layer around a command buffer builder that checks whether the commands can be executed in the
 /// given context related to render passes.
@@ -91,13 +92,8 @@ unsafe impl<I> CommandBufferBuilder for ContextCheckLayer<I>
     where I: CommandBufferBuilder
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/device_check.rs
+++ b/vulkano/src/command_buffer/cb/device_check.rs
@@ -15,6 +15,7 @@ use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use device::Device;
 use device::DeviceOwned;
+use instance::QueueFamily;
 use VulkanObject;
 
 /// Layer around a command buffer builder that checks whether the commands added to it belong to
@@ -52,13 +53,8 @@ unsafe impl<I> CommandBufferBuilder for DeviceCheckLayer<I>
     where I: CommandBufferBuilder
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/state_cache.rs
+++ b/vulkano/src/command_buffer/cb/state_cache.rs
@@ -16,6 +16,7 @@ use command_buffer::commands_raw;
 use command_buffer::DynamicState;
 use device::Device;
 use device::DeviceOwned;
+use instance::QueueFamily;
 use VulkanObject;
 use vk;
 
@@ -80,13 +81,8 @@ unsafe impl<I> CommandBufferBuilder for StateCacheLayer<I>
     where I: CommandBufferBuilder
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/submit_sync.rs
+++ b/vulkano/src/command_buffer/cb/submit_sync.rs
@@ -19,6 +19,7 @@ use command_buffer::CommandBuffer;
 use command_buffer::CommandBufferBuilder;
 use command_buffer::commands_raw;
 use image::ImageAccess;
+use instance::QueueFamily;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
@@ -108,13 +109,8 @@ unsafe impl<I> CommandBufferBuilder for SubmitSyncBuilderLayer<I>
     where I: CommandBufferBuilder
 {
     #[inline]
-    fn supports_graphics(&self) -> bool {
-        self.inner.supports_graphics()
-    }
-
-    #[inline]
-    fn supports_compute(&self) -> bool {
-        self.inner.supports_compute()
+    fn queue_family(&self) -> QueueFamily {
+        self.inner.queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/cb/sys.rs
+++ b/vulkano/src/command_buffer/cb/sys.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::AtomicBool;
 
 use buffer::BufferAccess;
 use command_buffer::CommandBuffer;
+use command_buffer::CommandBufferBuilder;
 use command_buffer::cb::CommandBufferBuild;
 use command_buffer::pool::AllocatedCommandBuffer;
 use command_buffer::pool::CommandPool;
@@ -27,6 +28,7 @@ use framebuffer::RenderPass;
 use framebuffer::RenderPassAbstract;
 use framebuffer::Subpass;
 use image::ImageAccess;
+use instance::QueueFamily;
 use sync::AccessFlagBits;
 use sync::PipelineStages;
 use sync::GpuFuture;
@@ -232,6 +234,13 @@ unsafe impl<P> DeviceOwned for UnsafeCommandBufferBuilder<P> where P: CommandPoo
     #[inline]
     fn device(&self) -> &Arc<Device> {
         &self.device
+    }
+}
+
+unsafe impl<P> CommandBufferBuilder for UnsafeCommandBufferBuilder<P> where P: CommandPool {
+    #[inline]
+    fn queue_family(&self) -> QueueFamily {
+        self.pool.as_ref().unwrap().queue_family()
     }
 }
 

--- a/vulkano/src/command_buffer/commands_raw/execute.rs
+++ b/vulkano/src/command_buffer/commands_raw/execute.rs
@@ -44,6 +44,12 @@ impl<Cb> CmdExecuteCommands<Cb> {
             command_buffer: command_buffer,
         }*/
     }
+
+    /// Returns the command buffer to be executed.
+    #[inline]
+    pub fn command_buffer(&self) -> &Cb {
+        &self.command_buffer
+    }
 }
 
 unsafe impl<Cb> DeviceOwned for CmdExecuteCommands<Cb>

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -22,6 +22,7 @@ use device::Device;
 use device::DeviceOwned;
 use device::Queue;
 use image::ImageAccess;
+use instance::QueueFamily;
 use sync::AccessFlagBits;
 use sync::DummyFuture;
 use sync::GpuFuture;
@@ -35,6 +36,12 @@ pub unsafe trait CommandBuffer: DeviceOwned {
 
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.
     fn inner(&self) -> &UnsafeCommandBuffer<Self::Pool>;
+
+    /// Returns the queue family of the command buffer.
+    #[inline]
+    fn queue_family(&self) -> QueueFamily {
+        self.inner().queue_family()
+    }
 
     /// Checks whether this command buffer is allowed to be submitted after the `future` and on
     /// the given queue.


### PR DESCRIPTION
This removes the necessary implementation of `CommandBufferBuilder::supports_*()` and replaces them with `CommandBufferBuilder::queue_family()`.

This allows us to implement `CommandBufferBuilder` on `UnsafeCommandBufferBuilder`, and removes the two parameters when constructing the queue type check layer.

Also implements `AddCommand<CmdExecuteCommands>` for the queue type check layer.
