### PR TITLE
Update vulkano-win and examples to winit 0.6

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ vulkano = { path = "../vulkano" }
 vulkano-win = { path = "../vulkano-win" }
 cgmath = "0.12.0"
 image = "0.6.1"
-winit = "0.5.2"
+winit = "0.6.4"
 time = "0.1.35"
 
 [build-dependencies]

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -33,7 +33,8 @@ fn main() {
                             .next().expect("no device available");
     println!("Using device: {} (type: {:?})", physical.name(), physical.ty());
 
-    let window = winit::WindowBuilder::new().build_vk_surface(&instance).unwrap();
+    let events_loop = winit::EventsLoop::new();
+    let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, &instance).unwrap();
 
     let queue = physical.queue_families().find(|q| q.supports_graphics() &&
                                                    window.surface().is_supported(q).unwrap_or(false))
@@ -192,11 +193,13 @@ fn main() {
             .then_signal_fence_and_flush().unwrap();
         submissions.push(Box::new(future) as Box<_>);
 
-        for ev in window.window().poll_events() {
+        let mut done = false;
+        events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::Closed => return,
+                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
                 _ => ()
             }
-        }
+        });
+        if done { return; }
     }
 }

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -37,7 +37,8 @@ fn main() {
                             .next().expect("no device available");
     println!("Using device: {} (type: {:?})", physical.name(), physical.ty());
 
-    let window = winit::WindowBuilder::new().build_vk_surface(&instance).unwrap();
+    let events_loop = winit::EventsLoop::new();
+    let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, &instance).unwrap();
 
     let queue = physical.queue_families().find(|q| q.supports_graphics() &&
                                                    window.surface().is_supported(q).unwrap_or(false))
@@ -198,11 +199,13 @@ fn main() {
             .then_signal_fence_and_flush().unwrap();
         submissions.push(Box::new(future) as Box<_>);
 
-        for ev in window.window().poll_events() {
+        let mut done = false;
+        events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::Closed => return,
+                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
                 _ => ()
             }
-        }
+        });
+        if done { return; }
     }
 }

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -93,6 +93,7 @@ fn main() {
     // Some little debug infos.
     println!("Using device: {} (type: {:?})", physical.name(), physical.ty());
 
+
     // The objective of this example is to draw a triangle on a window. To do so, we first need to
     // create the window.
     //
@@ -103,7 +104,8 @@ fn main() {
     //
     // This returns a `vulkano_win::Window` object that contains both a cross-platform winit
     // window and a cross-platform Vulkan surface that represents the surface of the window.
-    let window = winit::WindowBuilder::new().build_vk_surface(&instance).unwrap();
+    let events_loop = winit::EventsLoop::new();
+    let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, &instance).unwrap();
 
     // The next step is to choose which GPU queue will execute our draw commands.
     //
@@ -425,11 +427,13 @@ fn main() {
 
         // Handling the window events in order to close the program when the user wants to close
         // it.
-        for ev in window.window().poll_events() {
+        let mut done = false;
+        events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::Closed => return,
+                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
                 _ => ()
             }
-        }
+        });
+        if done { return; }
     }
 }

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -9,4 +9,4 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 vulkano = { version = "0.3.0", path = "../vulkano" }
-winit = "0.5.6"
+winit = "0.6.4"

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -10,7 +10,7 @@ use vulkano::instance::Instance;
 use vulkano::instance::InstanceExtensions;
 use vulkano::swapchain::Surface;
 use vulkano::swapchain::SurfaceCreationError;
-use winit::WindowBuilder;
+use winit::{EventsLoop, WindowBuilder};
 use winit::CreationError as WindowCreationError;
 
 pub fn required_extensions() -> InstanceExtensions {
@@ -32,12 +32,12 @@ pub fn required_extensions() -> InstanceExtensions {
 }
 
 pub trait VkSurfaceBuild {
-    fn build_vk_surface(self, instance: &Arc<Instance>) -> Result<Window, CreationError>;
+    fn build_vk_surface(self, events_loop: &EventsLoop, instance: &Arc<Instance>) -> Result<Window, CreationError>;
 }
 
 impl VkSurfaceBuild for WindowBuilder {
-    fn build_vk_surface(self, instance: &Arc<Instance>) -> Result<Window, CreationError> {
-        let window = try!(self.build());
+    fn build_vk_surface(self, events_loop: &EventsLoop, instance: &Arc<Instance>) -> Result<Window, CreationError> {
+        let window = try!(self.build(events_loop));
         let surface = try!(unsafe { winit_to_surface(instance, &window) });
 
         Ok(Window {


### PR DESCRIPTION
The current build of vulkano times out during `swapchain.acquire_next_image` for me after the first 2 to 60 frames or so in all the examples that needed updating, so I wasn't able to test this to my satisfaction, but it's simple enough so hopefully others can.