### PR TITLE
Allow specifying the behavior of the fence signal future

### DIFF
--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -252,8 +252,8 @@ unsafe impl<F, Cb> GpuFuture for CommandBufferExecFuture<F, Cb>
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
-        Some(&self.queue)
+    fn queue(&self) -> Option<Arc<Queue>> {
+        Some(self.queue.clone())
     }
 
     #[inline]

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -470,7 +470,7 @@ unsafe impl GpuFuture for SwapchainAcquireFuture {
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
+    fn queue(&self) -> Option<Arc<Queue>> {
         None
     }
 
@@ -656,13 +656,13 @@ unsafe impl<P> GpuFuture for PresentFuture<P> where P: GpuFuture {
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
+    fn queue(&self) -> Option<Arc<Queue>> {
         debug_assert!(match self.previous.queue() {
             None => true,
             Some(q) => q.is_same(&self.queue)
         });
 
-        Some(&self.queue)
+        Some(self.queue.clone())
     }
 
     #[inline]

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -31,7 +31,7 @@ pub fn join<F, S>(first: F, second: S) -> JoinFuture<F, S>
     assert_eq!(first.device().internal_object(), second.device().internal_object());
 
     if !first.queue_change_allowed() && !second.queue_change_allowed() {
-        assert!(first.queue().unwrap().is_same(second.queue().unwrap()));
+        assert!(first.queue().unwrap().is_same(&second.queue().unwrap()));
     }
 
     JoinFuture {
@@ -131,7 +131,7 @@ unsafe impl<A, B> GpuFuture for JoinFuture<A, B> where A: GpuFuture, B: GpuFutur
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
+    fn queue(&self) -> Option<Arc<Queue>> {
         match (self.first.queue(), self.second.queue()) {
             (Some(q1), Some(q2)) => if q1.is_same(&q2) {
                 Some(q1)

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -58,7 +58,7 @@ unsafe impl GpuFuture for NowFuture {
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
+    fn queue(&self) -> Option<Arc<Queue>> {
         None
     }
 

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -122,7 +122,7 @@ unsafe impl<F> GpuFuture for SemaphoreSignalFuture<F> where F: GpuFuture {
     }
 
     #[inline]
-    fn queue(&self) -> Option<&Arc<Queue>> {
+    fn queue(&self) -> Option<Arc<Queue>> {
         self.previous.queue()
     }
 


### PR DESCRIPTION
Also slightly changes the API of `GpuFuture` to return a `Arc<Queue>` instead of `&Arc<Queue>`.