### PR TITLE
Several modifications to device memory

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::fmt;
 use std::mem;
 use std::ptr;
 use std::ops::Deref;
@@ -17,9 +18,9 @@ use std::sync::Arc;
 
 use instance::MemoryType;
 use device::Device;
+use device::DeviceOwned;
 use memory::Content;
 use OomError;
-use SafeDeref;
 use VulkanObject;
 use VulkanPointers;
 use check_errors;
@@ -38,17 +39,16 @@ use vk;
 /// let mem_ty = device.physical_device().memory_types().next().unwrap();
 /// 
 /// // Allocates 1kB of memory.
-/// let memory = DeviceMemory::alloc(&device, mem_ty, 1024).unwrap();
+/// let memory = DeviceMemory::alloc(device.clone(), mem_ty, 1024).unwrap();
 /// ```
-#[derive(Debug)]
-pub struct DeviceMemory<D = Arc<Device>> where D: SafeDeref<Target = Device> {
+pub struct DeviceMemory {
     memory: vk::DeviceMemory,
-    device: D,
+    device: Arc<Device>,
     size: usize,
     memory_type_index: u32,
 }
 
-impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
+impl DeviceMemory {
     /// Allocates a chunk of memory from the device.
     ///
     /// Some platforms may have a limit on the maximum size of a single allocation. For example,
@@ -60,11 +60,9 @@ impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
     /// - Panics if `memory_type` doesn't belong to the same physical device as `device`.
     ///
     // TODO: VK_ERROR_TOO_MANY_OBJECTS error
-    // TODO: remove that `D` generic and use `Arc<Device>`
     #[inline]
-    pub fn alloc(device: &D, memory_type: MemoryType, size: usize)
-                 -> Result<DeviceMemory<D>, OomError>
-        where D: Clone
+    pub fn alloc(device: Arc<Device>, memory_type: MemoryType, size: usize)
+                 -> Result<DeviceMemory, OomError>
     {
         assert!(size >= 1);
         assert_eq!(device.physical_device().internal_object(),
@@ -74,9 +72,9 @@ impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
             return Err(OomError::OutOfDeviceMemory);
         }
 
-        let vk = device.pointers();
-
         let memory = unsafe {
+            let vk = device.pointers();
+
             let infos = vk::MemoryAllocateInfo {
                 sType: vk::STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
                 pNext: ptr::null(),
@@ -92,7 +90,7 @@ impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
 
         Ok(DeviceMemory {
             memory: memory,
-            device: device.clone(),
+            device: device,
             size: size,
             memory_type_index: memory_type.id(),
         })
@@ -105,14 +103,13 @@ impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
     /// - Panics if `memory_type` doesn't belong to the same physical device as `device`.
     /// - Panics if the memory type is not host-visible.
     ///
-    pub fn alloc_and_map(device: &D, memory_type: MemoryType, size: usize)
-                         -> Result<MappedDeviceMemory<D>, OomError>
-        where D: Clone
+    pub fn alloc_and_map(device: Arc<Device>, memory_type: MemoryType, size: usize)
+                         -> Result<MappedDeviceMemory, OomError>
     {
         let vk = device.pointers();
 
         assert!(memory_type.is_host_visible());
-        let mem = try!(DeviceMemory::alloc(device, memory_type, size));
+        let mem = try!(DeviceMemory::alloc(device.clone(), memory_type, size));
 
         let coherent = memory_type.is_host_coherent();
 
@@ -142,15 +139,26 @@ impl<D> DeviceMemory<D> where D: SafeDeref<Target = Device> {
     pub fn size(&self) -> usize {
         self.size
     }
+}
 
-    /// Returns the device associated with this allocation.
+unsafe impl DeviceOwned for DeviceMemory {
     #[inline]
-    pub fn device(&self) -> &Device {
+    fn device(&self) -> &Arc<Device> {
         &self.device
     }
 }
 
-unsafe impl<D> VulkanObject for DeviceMemory<D> where D: SafeDeref<Target = Device> {
+impl fmt::Debug for DeviceMemory {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("DeviceMemory")
+            .field("device", &*self.device)
+            .field("memory_type", &self.memory_type())
+            .field("size", &self.size)
+            .finish()
+    }
+}
+
+unsafe impl VulkanObject for DeviceMemory {
     type Object = vk::DeviceMemory;
 
     #[inline]
@@ -159,13 +167,12 @@ unsafe impl<D> VulkanObject for DeviceMemory<D> where D: SafeDeref<Target = Devi
     }
 }
 
-impl<D> Drop for DeviceMemory<D> where D: SafeDeref<Target = Device> {
+impl Drop for DeviceMemory {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            let device = self.device();
-            let vk = device.pointers();
-            vk.FreeMemory(device.internal_object(), self.memory, ptr::null());
+            let vk = self.device.pointers();
+            vk.FreeMemory(self.device.internal_object(), self.memory, ptr::null());
         }
     }
 }
@@ -190,7 +197,7 @@ impl<D> Drop for DeviceMemory<D> where D: SafeDeref<Target = Device> {
 ///                     .next().unwrap();    // Vk specs guarantee that this can't fail
 ///
 /// // Allocates 1kB of memory.
-/// let memory = DeviceMemory::alloc_and_map(&device, mem_ty, 1024).unwrap();
+/// let memory = DeviceMemory::alloc_and_map(device.clone(), mem_ty, 1024).unwrap();
 ///
 /// // Get access to the content. Note that this is very unsafe for two reasons: 1) the content is
 /// // uninitialized, and 2) the access is unsynchronized.
@@ -199,19 +206,29 @@ impl<D> Drop for DeviceMemory<D> where D: SafeDeref<Target = Device> {
 ///     content[12] = 54;       // `content` derefs to a `&[u8]` or a `&mut [u8]`
 /// }
 /// ```
-#[derive(Debug)]
-pub struct MappedDeviceMemory<D = Arc<Device>> where D: SafeDeref<Target = Device> {
-    memory: DeviceMemory<D>,
+pub struct MappedDeviceMemory {
+    memory: DeviceMemory,
     pointer: *mut c_void,
     coherent: bool,
 }
 
-impl<D> MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {
-    /// Returns the underlying `DeviceMemory`.
-    // TODO: impl AsRef instead?
-    #[inline]
-    pub fn memory(&self) -> &DeviceMemory<D> {
-        &self.memory
+// Note that `MappedDeviceMemory` doesn't implement `Drop`, as we don't need to unmap memory before
+// freeing it.
+//
+// Vulkan specs, documentation of `vkFreeMemory`:
+// > If a memory object is mapped at the time it is freed, it is implicitly unmapped.
+//
+
+impl MappedDeviceMemory {
+    /// Unmaps the memory. It will no longer be accessible from the CPU.
+    pub fn unmap(self) -> DeviceMemory {
+        unsafe {
+            let device = self.memory.device();
+            let vk = device.pointers();
+            vk.UnmapMemory(device.internal_object(), self.memory.memory);
+        }
+
+        self.memory
     }
 
     /// Gives access to the content of the memory.
@@ -229,7 +246,7 @@ impl<D> MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {
     ///   the `MappedDeviceMemory`.
     ///
     #[inline]
-    pub unsafe fn read_write<T: ?Sized>(&self, range: Range<usize>) -> CpuAccess<T, D>
+    pub unsafe fn read_write<T: ?Sized>(&self, range: Range<usize>) -> CpuAccess<T>
         where T: Content
     {
         let vk = self.memory.device().pointers();
@@ -258,31 +275,49 @@ impl<D> MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {
     }
 }
 
-unsafe impl<D> Send for MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {}
-unsafe impl<D> Sync for MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {}
-
-impl<D> Drop for MappedDeviceMemory<D> where D: SafeDeref<Target = Device> {
+impl AsRef<DeviceMemory> for MappedDeviceMemory {
     #[inline]
-    fn drop(&mut self) {
-        unsafe {
-            let device = self.memory.device();
-            let vk = device.pointers();
-            vk.UnmapMemory(device.internal_object(), self.memory.memory);
-        }
+    fn as_ref(&self) -> &DeviceMemory {
+        &self.memory
+    }
+}
+
+impl AsMut<DeviceMemory> for MappedDeviceMemory {
+    #[inline]
+    fn as_mut(&mut self) -> &mut DeviceMemory {
+        &mut self.memory
+    }
+}
+
+unsafe impl DeviceOwned for MappedDeviceMemory {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.memory.device()
+    }
+}
+
+unsafe impl Send for MappedDeviceMemory {}
+unsafe impl Sync for MappedDeviceMemory {}
+
+impl fmt::Debug for MappedDeviceMemory {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_tuple("MappedDeviceMemory")
+            .field(&self.memory)
+            .finish()
     }
 }
 
 /// Object that can be used to read or write the content of a `MappedDeviceMemory`.
 ///
 /// This object derefs to the content, just like a `MutexGuard` for example.
-pub struct CpuAccess<'a, T: ?Sized + 'a, D = Arc<Device>> where D: SafeDeref<Target = Device> + 'a {
+pub struct CpuAccess<'a, T: ?Sized + 'a> {
     pointer: *mut T,
-    mem: &'a MappedDeviceMemory<D>,
+    mem: &'a MappedDeviceMemory,
     coherent: bool,
     range: Range<usize>,
 }
 
-impl<'a, T: ?Sized + 'a, D: 'a> CpuAccess<'a, T, D> where D: SafeDeref<Target = Device> {
+impl<'a, T: ?Sized + 'a> CpuAccess<'a, T> {
     /// Builds a new `CpuAccess` to access a sub-part of the current `CpuAccess`.
     ///
     /// This function is unstable. Don't use it directly.
@@ -290,7 +325,7 @@ impl<'a, T: ?Sized + 'a, D: 'a> CpuAccess<'a, T, D> where D: SafeDeref<Target = 
     // TODO: decide what to do with this
     #[doc(hidden)]
     #[inline]
-    pub fn map<U: ?Sized + 'a, F>(self, f: F) -> CpuAccess<'a, U, D>
+    pub fn map<U: ?Sized + 'a, F>(self, f: F) -> CpuAccess<'a, U>
         where F: FnOnce(*mut T) -> *mut U
     {
         CpuAccess {
@@ -302,12 +337,10 @@ impl<'a, T: ?Sized + 'a, D: 'a> CpuAccess<'a, T, D> where D: SafeDeref<Target = 
     }
 }
 
-unsafe impl<'a, T: ?Sized + 'a, D: 'a> Send for CpuAccess<'a, T, D>
-    where D: SafeDeref<Target = Device> {}
-unsafe impl<'a, T: ?Sized + 'a, D: 'a> Sync for CpuAccess<'a, T, D>
-    where D: SafeDeref<Target = Device> {}
+unsafe impl<'a, T: ?Sized + 'a> Send for CpuAccess<'a, T> {}
+unsafe impl<'a, T: ?Sized + 'a> Sync for CpuAccess<'a, T> {}
 
-impl<'a, T: ?Sized + 'a, D: 'a> Deref for CpuAccess<'a, T, D> where D: SafeDeref<Target = Device> {
+impl<'a, T: ?Sized + 'a> Deref for CpuAccess<'a, T> {
     type Target = T;
 
     #[inline]
@@ -316,33 +349,31 @@ impl<'a, T: ?Sized + 'a, D: 'a> Deref for CpuAccess<'a, T, D> where D: SafeDeref
     }
 }
 
-impl<'a, T: ?Sized + 'a, D: 'a> DerefMut for CpuAccess<'a, T, D>
-    where D: SafeDeref<Target = Device>
-{
+impl<'a, T: ?Sized + 'a> DerefMut for CpuAccess<'a, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.pointer }
     }
 }
 
-impl<'a, T: ?Sized + 'a, D: 'a> Drop for CpuAccess<'a, T, D> where D: SafeDeref<Target = Device> {
+impl<'a, T: ?Sized + 'a> Drop for CpuAccess<'a, T> {
     #[inline]
     fn drop(&mut self) {
         // If the memory doesn't have the `coherent` flag, we need to flush the data.
         if !self.coherent {
-            let vk = self.mem.memory().device().pointers();
+            let vk = self.mem.as_ref().device().pointers();
 
             let range = vk::MappedMemoryRange {
                 sType: vk::STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
                 pNext: ptr::null(),
-                memory: self.mem.memory().internal_object(),
+                memory: self.mem.as_ref().internal_object(),
                 offset: self.range.start as u64,
                 size: (self.range.end - self.range.start) as u64,
             };
 
             // TODO: check result?
             unsafe {
-                vk.FlushMappedMemoryRanges(self.mem.memory().device().internal_object(),
+                vk.FlushMappedMemoryRanges(self.mem.as_ref().device().internal_object(),
                                            1, &range);
             }
         }
@@ -358,7 +389,7 @@ mod tests {
     fn create() {
         let (device, _) = gfx_dev_and_queue!();
         let mem_ty = device.physical_device().memory_types().next().unwrap();
-        let _ = DeviceMemory::alloc(&device, mem_ty, 256).unwrap();
+        let _ = DeviceMemory::alloc(device.clone(), mem_ty, 256).unwrap();
     }
 
     #[test]
@@ -366,7 +397,7 @@ mod tests {
     fn zero_size() {
         let (device, _) = gfx_dev_and_queue!();
         let mem_ty = device.physical_device().memory_types().next().unwrap();
-        let _ = DeviceMemory::alloc(&device, mem_ty, 0);
+        let _ = DeviceMemory::alloc(device.clone(), mem_ty, 0);
     }
 
     #[test]
@@ -376,7 +407,7 @@ mod tests {
         let mem_ty = device.physical_device().memory_types().filter(|m| !m.is_lazily_allocated())
                            .next().unwrap();
     
-        match DeviceMemory::alloc(&device, mem_ty, 0xffffffffffffffff) {
+        match DeviceMemory::alloc(device.clone(), mem_ty, 0xffffffffffffffff) {
             Err(OomError::OutOfDeviceMemory) => (),
             _ => panic!()
         }
@@ -392,7 +423,7 @@ mod tests {
         let mut allocs = Vec::new();
     
         for _ in 0 .. 4 {
-            match DeviceMemory::alloc(&device, mem_ty, heap_size / 3) {
+            match DeviceMemory::alloc(device.clone(), mem_ty, heap_size / 3) {
                 Err(OomError::OutOfDeviceMemory) => return,     // test succeeded
                 Ok(a) => allocs.push(a),
                 _ => ()

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -71,7 +71,7 @@
 //! // Taking the first memory type for the sake of this example.
 //! let ty = device.physical_device().memory_types().next().unwrap();
 //! 
-//! let alloc = DeviceMemory::alloc(&device, ty, 1024).expect("Failed to allocate memory");
+//! let alloc = DeviceMemory::alloc(device.clone(), ty, 1024).expect("Failed to allocate memory");
 //! 
 //! // The memory is automatically free'd when `alloc` is destroyed.
 //! ```

--- a/vulkano/src/memory/pool/host_visible.rs
+++ b/vulkano/src/memory/pool/host_visible.rs
@@ -88,7 +88,7 @@ impl StdHostVisibleMemoryTypePool {
 
             // Try append at the end.
             let last_end = entries.last().map(|e| align(e.end, alignment)).unwrap_or(0);
-            if last_end + size <= dev_mem.memory().size() {
+            if last_end + size <= (**dev_mem).as_ref().size() {
                 entries.push(last_end .. last_end + size);
                 return Ok(StdHostVisibleMemoryTypePoolAlloc {
                     pool: me.clone(),
@@ -103,7 +103,7 @@ impl StdHostVisibleMemoryTypePool {
         let new_block = {
             const MIN_BLOCK_SIZE: usize = 8 * 1024 * 1024;      // 8 MB
             let to_alloc = cmp::max(MIN_BLOCK_SIZE, size.next_power_of_two());
-            let new_block = try!(DeviceMemory::alloc_and_map(&me.device, me.memory_type(), to_alloc));
+            let new_block = try!(DeviceMemory::alloc_and_map(me.device.clone(), me.memory_type(), to_alloc));
             Arc::new(new_block)
         };
 

--- a/vulkano/src/memory/pool/non_host_visible.rs
+++ b/vulkano/src/memory/pool/non_host_visible.rs
@@ -102,7 +102,7 @@ impl StdNonHostVisibleMemoryTypePool {
         let new_block = {
             const MIN_BLOCK_SIZE: usize = 8 * 1024 * 1024;      // 8 MB
             let to_alloc = cmp::max(MIN_BLOCK_SIZE, size.next_power_of_two());
-            let new_block = try!(DeviceMemory::alloc(&me.device, me.memory_type(), to_alloc));
+            let new_block = try!(DeviceMemory::alloc(me.device.clone(), me.memory_type(), to_alloc));
             Arc::new(new_block)
         };
 

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -122,7 +122,7 @@ unsafe impl MemoryPoolAlloc for StdMemoryPoolAlloc {
     fn memory(&self) -> &DeviceMemory {
         match self.inner {
             StdMemoryPoolAllocInner::NonHostVisible(ref mem) => mem.memory(),
-            StdMemoryPoolAllocInner::HostVisible(ref mem) => mem.memory().memory(),
+            StdMemoryPoolAllocInner::HostVisible(ref mem) => mem.memory().as_ref(),
         }
     }
 


### PR DESCRIPTION
- Removes the `D` generic.
- Constructor takes a `Arc<Device>` as parameter instead of a ref, so that the cloning is explicit.
- Adds `MappedDeviceMemory::unmap`.
- Removes the destructor of `MappedDeviceMemory`, as freeing memory also unmaps it implicitely.
- Implements `Debug` in a nicer way.
- Implements `AsRef<DeviceMemory>` for `MappedDeviceMemory`.
- Implements `DeviceOwned` instead of a `device()` method.