### PR TITLE
Require PipelineLayoutDesc for PipelineLayoutAbstract

### DIFF
--- a/vulkano/src/command_buffer/commands_raw/bind_descriptor_sets.rs
+++ b/vulkano/src/command_buffer/commands_raw/bind_descriptor_sets.rs
@@ -57,7 +57,7 @@ impl<S, P> CmdBindDescriptorSets<S, P>
     pub fn new(graphics: bool, pipeline_layout: P, sets: S)
                -> Result<CmdBindDescriptorSets<S, P>, CmdBindDescriptorSetsError> 
     {
-        if !PipelineLayoutSetsCompatible::is_compatible(pipeline_layout.desc(), &sets) {
+        if !PipelineLayoutSetsCompatible::is_compatible(&pipeline_layout, &sets) {
             return Err(CmdBindDescriptorSetsError::IncompatibleSets);
         }
 

--- a/vulkano/src/command_buffer/commands_raw/push_constants.rs
+++ b/vulkano/src/command_buffer/commands_raw/push_constants.rs
@@ -43,7 +43,7 @@ impl<Pc, Pl> CmdPushConstants<Pc, Pl>
     pub fn new(pipeline_layout: Pl, push_constants: Pc)
                -> Result<CmdPushConstants<Pc, Pl>, CmdPushConstantsError> 
     {
-        if !PipelineLayoutPushConstantsCompatible::is_compatible(pipeline_layout.desc(), &push_constants) {
+        if !PipelineLayoutPushConstantsCompatible::is_compatible(&pipeline_layout, &push_constants) {
             return Err(CmdPushConstantsError::IncompatibleData);
         }
 
@@ -78,8 +78,8 @@ unsafe impl<'a, P, Pc, Pl> AddCommand<&'a CmdPushConstants<Pc, Pl>> for UnsafeCo
 
             let data_raw = &command.push_constants as *const Pc as *const u8;
             
-            for num_range in 0 .. command.pipeline_layout.desc().num_push_constants_ranges() {
-                let range = match command.pipeline_layout.desc().push_constants_range(num_range) {
+            for num_range in 0 .. command.pipeline_layout.num_push_constants_ranges() {
+                let range = match command.pipeline_layout.push_constants_range(num_range) {
                     Some(r) => r,
                     None => continue
                 };

--- a/vulkano/src/descriptor/descriptor_set/simple.rs
+++ b/vulkano/src/descriptor/descriptor_set/simple.rs
@@ -155,9 +155,9 @@ impl<L> SimpleDescriptorSetBuilder<L, ()> where L: PipelineLayoutAbstract {
     /// - Panics if the set id is out of range.
     ///
     pub fn new(layout: L, set_id: usize) -> SimpleDescriptorSetBuilder<L, ()> {
-        assert!(layout.desc().num_sets() > set_id);
+        assert!(layout.num_sets() > set_id);
 
-        let cap = layout.desc().num_bindings_in_set(set_id).unwrap_or(0);
+        let cap = layout.num_bindings_in_set(set_id).unwrap_or(0);
 
         SimpleDescriptorSetBuilder {
             layout: layout,
@@ -210,9 +210,9 @@ unsafe impl<L, R, T> SimpleDescriptorSetBufferExt<L, R> for T
     {
         let buffer = self.access();
 
-        let (set_id, binding_id) = i.layout.desc().descriptor_by_name(name).unwrap();    // TODO: Result instead
+        let (set_id, binding_id) = i.layout.descriptor_by_name(name).unwrap();    // TODO: Result instead
         assert_eq!(set_id, i.set_id);       // TODO: Result instead
-        let desc = i.layout.desc().descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
+        let desc = i.layout.descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
 
         assert!(desc.array_count == 1);     // not implemented
         i.writes.push(match desc.ty.ty().unwrap() {
@@ -260,9 +260,9 @@ unsafe impl<L, R, T> SimpleDescriptorSetImageExt<L, R> for T
     {
         let image_view = self.access();
 
-        let (set_id, binding_id) = i.layout.desc().descriptor_by_name(name).unwrap();    // TODO: Result instead
+        let (set_id, binding_id) = i.layout.descriptor_by_name(name).unwrap();    // TODO: Result instead
         assert_eq!(set_id, i.set_id);       // TODO: Result instead
-        let desc = i.layout.desc().descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
+        let desc = i.layout.descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
 
         assert!(desc.array_count == 1);     // not implemented
         i.writes.push(match desc.ty.ty().unwrap() {
@@ -308,9 +308,9 @@ unsafe impl<L, R, T> SimpleDescriptorSetImageExt<L, R> for (T, Arc<Sampler>)
     {
         let image_view = self.0.access();
 
-        let (set_id, binding_id) = i.layout.desc().descriptor_by_name(name).unwrap();    // TODO: Result instead
+        let (set_id, binding_id) = i.layout.descriptor_by_name(name).unwrap();    // TODO: Result instead
         assert_eq!(set_id, i.set_id);       // TODO: Result instead
-        let desc = i.layout.desc().descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
+        let desc = i.layout.descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
 
         assert!(desc.array_count == 1);     // not implemented
         i.writes.push(match desc.ty.ty().unwrap() {
@@ -349,9 +349,9 @@ unsafe impl<L, R, T> SimpleDescriptorSetImageExt<L, R> for Vec<(T, Arc<Sampler>)
     fn add_me(self, mut i: SimpleDescriptorSetBuilder<L, R>, name: &str)
               -> SimpleDescriptorSetBuilder<L, Self::Out>
     {
-        let (set_id, binding_id) = i.layout.desc().descriptor_by_name(name).unwrap();    // TODO: Result instead
+        let (set_id, binding_id) = i.layout.descriptor_by_name(name).unwrap();    // TODO: Result instead
         assert_eq!(set_id, i.set_id);       // TODO: Result instead
-        let desc = i.layout.desc().descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
+        let desc = i.layout.descriptor(set_id, binding_id).unwrap();     // TODO: Result instead
 
         assert_eq!(desc.array_count as usize, self.len());     // not implemented
 

--- a/vulkano/src/descriptor/pipeline_layout/sys.rs
+++ b/vulkano/src/descriptor/pipeline_layout/sys.rs
@@ -21,6 +21,7 @@ use VulkanObject;
 use VulkanPointers;
 use vk;
 
+use descriptor::descriptor::DescriptorDesc;
 use descriptor::descriptor::ShaderStages;
 use descriptor::descriptor_set::UnsafeDescriptorSetLayout;
 use descriptor::pipeline_layout::PipelineLayoutDesc;
@@ -174,13 +175,42 @@ unsafe impl<D> PipelineLayoutAbstract for PipelineLayout<D> where D: PipelineLay
     }
 
     #[inline]
-    fn desc(&self) -> &PipelineLayoutDescNames {
-        &self.desc
+    fn descriptor_set_layout(&self, index: usize) -> Option<&Arc<UnsafeDescriptorSetLayout>> {
+        self.layouts.get(index)
+    }
+}
+
+unsafe impl<D> PipelineLayoutDesc for PipelineLayout<D> where D: PipelineLayoutDesc {
+    #[inline]
+    fn num_sets(&self) -> usize {
+        self.desc.num_sets()
     }
 
     #[inline]
-    fn descriptor_set_layout(&self, index: usize) -> Option<&Arc<UnsafeDescriptorSetLayout>> {
-        self.layouts.get(index)
+    fn num_bindings_in_set(&self, set: usize) -> Option<usize> {
+        self.desc.num_bindings_in_set(set)
+    }
+
+    #[inline]
+    fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
+        self.desc.descriptor(set, binding)
+    }
+
+    #[inline]
+    fn num_push_constants_ranges(&self) -> usize {
+        self.desc.num_push_constants_ranges()
+    }
+
+    #[inline]
+    fn push_constants_range(&self, num: usize) -> Option<PipelineLayoutDescPcRange> {
+        self.desc.push_constants_range(num)
+    }
+}
+
+unsafe impl<D> PipelineLayoutDescNames for PipelineLayout<D> where D: PipelineLayoutDescNames {
+    #[inline]
+    fn descriptor_by_name(&self, name: &str) -> Option<(usize, usize)> {
+        self.desc.descriptor_by_name(name)
     }
 }
 

--- a/vulkano/src/descriptor/pipeline_layout/traits.rs
+++ b/vulkano/src/descriptor/pipeline_layout/traits.rs
@@ -25,19 +25,14 @@ use device::DeviceOwned;
 use SafeDeref;
 
 /// Trait for objects that describe the layout of the descriptors and push constants of a pipeline.
-pub unsafe trait PipelineLayoutAbstract: DeviceOwned {
+// TODO: meh for PipelineLayoutDescNames ; the `Names` thing shouldn't be mandatory
+pub unsafe trait PipelineLayoutAbstract: PipelineLayoutDescNames + DeviceOwned {
     /// Returns an opaque object that allows internal access to the pipeline layout.
     ///
     /// Can be obtained by calling `PipelineLayoutAbstract::sys()` on the pipeline layout.
     ///
     /// > **Note**: This is an internal function that you normally don't need to call.
     fn sys(&self) -> PipelineLayoutSys;
-
-    /// Returns the description of the pipeline layout.
-    ///
-    /// Can be obtained by calling `PipelineLayoutAbstract::desc()` on the pipeline layout.
-    // TODO: meh for `PipelineLayoutDescNames instead of `PipelineLayoutDesc`
-    fn desc(&self) -> &PipelineLayoutDescNames;
 
     /// Returns the `UnsafeDescriptorSetLayout` object of the specified set index.
     ///
@@ -49,11 +44,6 @@ unsafe impl<T> PipelineLayoutAbstract for T where T: SafeDeref, T::Target: Pipel
     #[inline]
     fn sys(&self) -> PipelineLayoutSys {
         (**self).sys()
-    }
-
-    #[inline]
-    fn desc(&self) -> &PipelineLayoutDescNames {
-        (**self).desc()
     }
 
     #[inline]

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -14,12 +14,15 @@ use std::mem;
 use std::ptr;
 use std::sync::Arc;
 
-use descriptor::PipelineLayoutAbstract;
+use descriptor::descriptor::DescriptorDesc;
 use descriptor::descriptor_set::UnsafeDescriptorSetLayout;
 use descriptor::pipeline_layout::PipelineLayout;
 use descriptor::pipeline_layout::PipelineLayoutSys;
+use descriptor::pipeline_layout::PipelineLayoutDesc;
 use descriptor::pipeline_layout::PipelineLayoutDescNames;
+use descriptor::pipeline_layout::PipelineLayoutDescPcRange;
 use descriptor::pipeline_layout::PipelineLayoutSuperset;
+use descriptor::pipeline_layout::PipelineLayoutAbstract;
 use descriptor::pipeline_layout::PipelineLayoutNotSupersetError;
 use pipeline::shader::ComputeShaderEntryPoint;
 use pipeline::shader::SpecializationConstants;
@@ -173,13 +176,42 @@ unsafe impl<Pl> PipelineLayoutAbstract for ComputePipeline<Pl> where Pl: Pipelin
     }
 
     #[inline]
-    fn desc(&self) -> &PipelineLayoutDescNames {
-        self.layout().desc()
+    fn descriptor_set_layout(&self, index: usize) -> Option<&Arc<UnsafeDescriptorSetLayout>> {
+        self.layout().descriptor_set_layout(index)
+    }
+}
+
+unsafe impl<Pl> PipelineLayoutDesc for ComputePipeline<Pl> where Pl: PipelineLayoutDesc {
+    #[inline]
+    fn num_sets(&self) -> usize {
+        self.pipeline_layout.num_sets()
     }
 
     #[inline]
-    fn descriptor_set_layout(&self, index: usize) -> Option<&Arc<UnsafeDescriptorSetLayout>> {
-        self.layout().descriptor_set_layout(index)
+    fn num_bindings_in_set(&self, set: usize) -> Option<usize> {
+        self.pipeline_layout.num_bindings_in_set(set)
+    }
+
+    #[inline]
+    fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
+        self.pipeline_layout.descriptor(set, binding)
+    }
+
+    #[inline]
+    fn num_push_constants_ranges(&self) -> usize {
+        self.pipeline_layout.num_push_constants_ranges()
+    }
+
+    #[inline]
+    fn push_constants_range(&self, num: usize) -> Option<PipelineLayoutDescPcRange> {
+        self.pipeline_layout.push_constants_range(num)
+    }
+}
+
+unsafe impl<Pl> PipelineLayoutDescNames for ComputePipeline<Pl> where Pl: PipelineLayoutDescNames {
+    #[inline]
+    fn descriptor_by_name(&self, name: &str) -> Option<(usize, usize)> {
+        self.pipeline_layout.descriptor_by_name(name)
     }
 }
 


### PR DESCRIPTION
So that the API is similar to render passes.

Also makes things cleaner in my opinion, as it removes an indirection.
