### PR TITLE
Buffer usage rework

### DIFF
--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -69,7 +69,7 @@ fn main() {
     impl_vertex!(Vertex, position);
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer::<[Vertex]>
-                               ::from_iter(&device, &vulkano::buffer::BufferUsage::all(),
+                               ::from_iter(&device, vulkano::buffer::BufferUsage::all(),
                                        Some(queue.family()), [
                                            Vertex { position: [-0.5, -0.5 ] },
                                            Vertex { position: [-0.5,  0.5 ] },
@@ -112,7 +112,7 @@ fn main() {
 
         // TODO: staging buffer instead
         vulkano::buffer::cpu_access::CpuAccessibleBuffer::<[[u8; 4]]>
-            ::from_iter(&device, &vulkano::buffer::BufferUsage::all(),
+            ::from_iter(&device, vulkano::buffer::BufferUsage::all(),
                         Some(queue.family()), image_data_chunks)
                         .expect("failed to create buffer")
     };

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -72,15 +72,15 @@ fn main() {
     let depth_buffer = vulkano::image::attachment::AttachmentImage::transient(&device, images[0].dimensions(), vulkano::format::D16Unorm).unwrap().access();
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, &vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())
+                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     let normals_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, &vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::NORMALS.iter().cloned())
+                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::NORMALS.iter().cloned())
                                 .expect("failed to create buffer");
 
     let index_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, &vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::INDICES.iter().cloned())
+                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::INDICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     // note: this teapot was meant for OpenGL where the origin is at the lower left
@@ -90,7 +90,7 @@ fn main() {
     let scale = cgmath::Matrix4::from_scale(0.01);
 
     let uniform_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer::<vs::ty::Data>
-                               ::from_data(&device, &vulkano::buffer::BufferUsage::all(), Some(queue.family()), 
+                               ::from_data(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), 
                                 vs::ty::Data {
                                     world : <cgmath::Matrix4<f32> as cgmath::SquareMatrix>::identity().into(),
                                     view : (view * scale).into(),

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -194,7 +194,7 @@ fn main() {
         struct Vertex { position: [f32; 2] }
         impl_vertex!(Vertex, position);
 
-        CpuAccessibleBuffer::from_iter(&device, &BufferUsage::all(), Some(queue.family()), [
+        CpuAccessibleBuffer::from_iter(&device, BufferUsage::all(), Some(queue.family()), [
             Vertex { position: [-0.5, -0.25] },
             Vertex { position: [0.0, 0.5] },
             Vertex { position: [0.25, -0.1] }

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -31,7 +31,7 @@ use smallvec::SmallVec;
 use buffer::sys::BufferCreationError;
 use buffer::sys::SparseLevel;
 use buffer::sys::UnsafeBuffer;
-use buffer::sys::Usage;
+use buffer::BufferUsage;
 use buffer::traits::BufferAccess;
 use buffer::traits::BufferInner;
 use buffer::traits::Buffer;
@@ -77,7 +77,7 @@ impl<T> CpuAccessibleBuffer<T> {
     /// Deprecated. Use `from_data` instead.
     #[deprecated]
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: &Usage, queue_families: I)
+    pub fn new<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -87,7 +87,7 @@ impl<T> CpuAccessibleBuffer<T> {
     }
 
     /// Builds a new buffer with some data in it. Only allowed for sized data.
-    pub fn from_data<'a, I>(device: &Arc<Device>, usage: &Usage, queue_families: I, data: T)
+    pub fn from_data<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I, data: T)
                             -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: Content + 'static,
@@ -112,7 +112,7 @@ impl<T> CpuAccessibleBuffer<T> {
 
     /// Builds a new uninitialized buffer. Only allowed for sized data.
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(device: &Arc<Device>, usage: &Usage, queue_families: I)
+    pub unsafe fn uninitialized<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
                                        -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -123,7 +123,7 @@ impl<T> CpuAccessibleBuffer<T> {
 impl<T> CpuAccessibleBuffer<[T]> {
     /// Builds a new buffer that contains an array `T`. The initial data comes from an iterator
     /// that produces that list of Ts.
-    pub fn from_iter<'a, I, Q>(device: &Arc<Device>, usage: &Usage, queue_families: Q, data: I)
+    pub fn from_iter<'a, I, Q>(device: &Arc<Device>, usage: &BufferUsage, queue_families: Q, data: I)
                                -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: ExactSizeIterator<Item = T>,
               T: Content + 'static,
@@ -154,7 +154,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
     // TODO: remove
     #[inline]
     #[deprecated]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &Usage, queue_families: I)
+    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -165,7 +165,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
 
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(device: &Arc<Device>, len: usize, usage: &Usage,
+    pub unsafe fn uninitialized_array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage,
                                              queue_families: I)
                                              -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
@@ -181,7 +181,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &Usage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
                              -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -77,7 +77,7 @@ impl<T> CpuAccessibleBuffer<T> {
     /// Deprecated. Use `from_data` instead.
     #[deprecated]
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
+    pub fn new<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -87,7 +87,7 @@ impl<T> CpuAccessibleBuffer<T> {
     }
 
     /// Builds a new buffer with some data in it. Only allowed for sized data.
-    pub fn from_data<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I, data: T)
+    pub fn from_data<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I, data: T)
                             -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: Content + 'static,
@@ -112,7 +112,7 @@ impl<T> CpuAccessibleBuffer<T> {
 
     /// Builds a new uninitialized buffer. Only allowed for sized data.
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
+    pub unsafe fn uninitialized<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
                                        -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -123,7 +123,7 @@ impl<T> CpuAccessibleBuffer<T> {
 impl<T> CpuAccessibleBuffer<[T]> {
     /// Builds a new buffer that contains an array `T`. The initial data comes from an iterator
     /// that produces that list of Ts.
-    pub fn from_iter<'a, I, Q>(device: &Arc<Device>, usage: &BufferUsage, queue_families: Q, data: I)
+    pub fn from_iter<'a, I, Q>(device: &Arc<Device>, usage: BufferUsage, queue_families: Q, data: I)
                                -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: ExactSizeIterator<Item = T>,
               T: Content + 'static,
@@ -154,7 +154,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
     // TODO: remove
     #[inline]
     #[deprecated]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
+    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -165,7 +165,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
 
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage,
+    pub unsafe fn uninitialized_array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage,
                                              queue_families: I)
                                              -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
@@ -181,7 +181,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
                              -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -195,7 +195,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device, size, &usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device, size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -21,7 +21,7 @@ use smallvec::SmallVec;
 use buffer::sys::BufferCreationError;
 use buffer::sys::SparseLevel;
 use buffer::sys::UnsafeBuffer;
-use buffer::sys::Usage;
+use buffer::BufferUsage;
 use buffer::traits::BufferAccess;
 use buffer::traits::BufferInner;
 use buffer::traits::Buffer;
@@ -43,7 +43,7 @@ use OomError;
 ///
 /// This buffer is especially suitable when you want to upload or download some data at each frame.
 ///
-/// # Usage
+/// # BufferUsage
 ///
 /// A `CpuBufferPool` is a bit similar to a `Vec`. You start by creating an empty pool, then you
 /// grab elements from the pool and use them, and if the pool is full it will automatically grow
@@ -71,7 +71,7 @@ pub struct CpuBufferPool<T: ?Sized, A = Arc<StdMemoryPool>> where A: MemoryPool 
     one_size: usize,
 
     // Buffer usage.
-    usage: Usage,
+    usage: BufferUsage,
 
     // Queue families allowed to access this buffer.
     queue_families: SmallVec<[u32; 4]>,
@@ -131,7 +131,7 @@ pub struct CpuBufferPoolSubbuffer<T: ?Sized, A> where A: MemoryPool {
 
 impl<T> CpuBufferPool<T> {
     #[inline]
-    pub fn new<'a, I>(device: Arc<Device>, usage: &Usage, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, usage: &BufferUsage, queue_families: I)
                       -> CpuBufferPool<T>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -146,13 +146,13 @@ impl<T> CpuBufferPool<T> {
     /// family accesses.
     #[inline]
     pub fn upload(device: Arc<Device>) -> CpuBufferPool<T> {
-        CpuBufferPool::new(device, &Usage::transfer_source(), iter::empty())
+        CpuBufferPool::new(device, &BufferUsage::transfer_source(), iter::empty())
     }
 }
 
 impl<T> CpuBufferPool<[T]> {
     #[inline]
-    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: &Usage, queue_families: I)
+    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
                       -> CpuBufferPool<[T]>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -164,7 +164,7 @@ impl<T> CpuBufferPool<[T]> {
 
 impl<T: ?Sized> CpuBufferPool<T> {
     pub unsafe fn raw<'a, I>(device: Arc<Device>, one_size: usize,
-                             usage: &Usage, queue_families: I) -> CpuBufferPool<T>
+                             usage: &BufferUsage, queue_families: I) -> CpuBufferPool<T>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
         let queue_families = queue_families.into_iter().map(|f| f.id())

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -131,7 +131,7 @@ pub struct CpuBufferPoolSubbuffer<T: ?Sized, A> where A: MemoryPool {
 
 impl<T> CpuBufferPool<T> {
     #[inline]
-    pub fn new<'a, I>(device: Arc<Device>, usage: &BufferUsage, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I)
                       -> CpuBufferPool<T>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -146,13 +146,13 @@ impl<T> CpuBufferPool<T> {
     /// family accesses.
     #[inline]
     pub fn upload(device: Arc<Device>) -> CpuBufferPool<T> {
-        CpuBufferPool::new(device, &BufferUsage::transfer_source(), iter::empty())
+        CpuBufferPool::new(device, BufferUsage::transfer_source(), iter::empty())
     }
 }
 
 impl<T> CpuBufferPool<[T]> {
     #[inline]
-    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
+    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
                       -> CpuBufferPool<[T]>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -164,7 +164,7 @@ impl<T> CpuBufferPool<[T]> {
 
 impl<T: ?Sized> CpuBufferPool<T> {
     pub unsafe fn raw<'a, I>(device: Arc<Device>, one_size: usize,
-                             usage: &BufferUsage, queue_families: I) -> CpuBufferPool<T>
+                             usage: BufferUsage, queue_families: I) -> CpuBufferPool<T>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
         let queue_families = queue_families.into_iter().map(|f| f.id())
@@ -265,7 +265,7 @@ impl<T, A> CpuBufferPool<T, A> where A: MemoryPool {
                     None => return Err(OomError::OutOfDeviceMemory),
                 };
 
-                match UnsafeBuffer::new(&self.device, total_size, &self.usage, sharing, SparseLevel::none()) {
+                match UnsafeBuffer::new(&self.device, total_size, self.usage, sharing, SparseLevel::none()) {
                     Ok(b) => b,
                     Err(BufferCreationError::OomError(err)) => return Err(err),
                     Err(_) => unreachable!()        // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -63,7 +63,7 @@ pub struct DeviceLocalBuffer<T: ?Sized, A = Arc<StdMemoryPool>> where A: MemoryP
 impl<T> DeviceLocalBuffer<T> {
     /// Builds a new buffer. Only allowed for sized data.
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
+    pub fn new<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -76,7 +76,7 @@ impl<T> DeviceLocalBuffer<T> {
 impl<T> DeviceLocalBuffer<[T]> {
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
+    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -93,7 +93,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
                              -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -107,7 +107,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device, size, &usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device, size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -22,7 +22,7 @@ use smallvec::SmallVec;
 use buffer::sys::BufferCreationError;
 use buffer::sys::SparseLevel;
 use buffer::sys::UnsafeBuffer;
-use buffer::sys::Usage;
+use buffer::BufferUsage;
 use buffer::traits::BufferAccess;
 use buffer::traits::BufferInner;
 use buffer::traits::Buffer;
@@ -63,7 +63,7 @@ pub struct DeviceLocalBuffer<T: ?Sized, A = Arc<StdMemoryPool>> where A: MemoryP
 impl<T> DeviceLocalBuffer<T> {
     /// Builds a new buffer. Only allowed for sized data.
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: &Usage, queue_families: I)
+    pub fn new<'a, I>(device: &Arc<Device>, usage: &BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -76,7 +76,7 @@ impl<T> DeviceLocalBuffer<T> {
 impl<T> DeviceLocalBuffer<[T]> {
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &Usage, queue_families: I)
+    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: &BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -93,7 +93,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &Usage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
                              -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -93,12 +93,12 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_data<'a, I>(data: T, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_data<'a, I>(data: T, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
                     -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_data(queue.device(), &BufferUsage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_data(queue.device(), BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -109,7 +109,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_buffer<'a, B, I>(source: B, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_buffer<'a, B, I>(source: B, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
                 -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), OomError>
         where B: Buffer + TypedBuffer<Content = T> + DeviceOwned,      // TODO: remove + DeviceOwned once Buffer requires it
               B::Access: 'static + Clone + Send + Sync,
@@ -140,7 +140,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     }
 
     /// Builds an `ImmutableBuffer` that copies its data from another buffer.
-    pub fn from_buffer_with_builder<'a, B, I, Cb, O>(source: B, usage: &BufferUsage, queue_families: I,
+    pub fn from_buffer_with_builder<'a, B, I, Cb, O>(source: B, usage: BufferUsage, queue_families: I,
                                                      builder: Cb)
                 -> Result<(Arc<ImmutableBuffer<T>>, O), ImmutableBufferFromBufferWithBuilderError>
         where B: Buffer + TypedBuffer<Content = T> + DeviceOwned,      // TODO: remove + DeviceOwned once Buffer requires it
@@ -152,11 +152,11 @@ impl<T: ?Sized> ImmutableBuffer<T> {
             // We automatically set `transfer_dest` to true in order to avoid annoying errors.
             let actual_usage = BufferUsage {
                 transfer_dest: true,
-                .. *usage
+                .. usage
             };
 
             let (buffer, init) = ImmutableBuffer::raw(source.device().clone(), source.size(),
-                                                      &actual_usage, queue_families)?;
+                                                      actual_usage, queue_families)?;
 
             let builder = builder.copy_buffer(source, init)?;
             Ok((buffer, builder))
@@ -182,7 +182,7 @@ impl<T> ImmutableBuffer<T> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(device: Arc<Device>, usage: &BufferUsage, queue_families: I)
+    pub unsafe fn uninitialized<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I)
                 -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -191,13 +191,13 @@ impl<T> ImmutableBuffer<T> {
 }
 
 impl<T> ImmutableBuffer<[T]> {
-    pub fn from_iter<'a, D, I>(data: D, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_iter<'a, D, I>(data: D, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
                 -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferFromBufferFuture), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               D: ExactSizeIterator<Item = T>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_iter(queue.device(), &BufferUsage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_iter(queue.device(), BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -219,7 +219,7 @@ impl<T> ImmutableBuffer<[T]> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(device: Arc<Device>, len: usize, usage: &BufferUsage,
+    pub unsafe fn uninitialized_array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage,
                                              queue_families: I)
               -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferInitialization<[T]>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
@@ -245,7 +245,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     ///   data.
     ///
     #[inline]
-    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
                              -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -255,7 +255,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
 
     // Internal implementation of `raw`. This is separated from `raw` so that it doesn't need to be
     // inlined.
-    unsafe fn raw_impl(device: Arc<Device>, size: usize, usage: &BufferUsage,
+    unsafe fn raw_impl(device: Arc<Device>, size: usize, usage: BufferUsage,
                        queue_families: SmallVec<[u32; 4]>)
                        -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
     {
@@ -266,7 +266,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(&device, size, &usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(&device, size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other
@@ -527,11 +527,11 @@ mod tests {
     fn from_data_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_data(12u32, &BufferUsage::all(),
+        let (buffer, _) = ImmutableBuffer::from_data(12u32, BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
+        let dest = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
                                                   iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -548,11 +548,11 @@ mod tests {
     fn from_iter_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_iter((0 .. 512u32).map(|n| n * 2), &BufferUsage::all(),
+        let (buffer, _) = ImmutableBuffer::from_iter((0 .. 512u32).map(|n| n * 2), BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_iter(&device, &BufferUsage::all(),
+        let dest = CpuAccessibleBuffer::from_iter(&device, BufferUsage::all(),
                                                   iter::once(queue.family()),
                                                   (0 .. 512).map(|_| 0u32)).unwrap();
 
@@ -573,7 +573,7 @@ mod tests {
     fn writing_forbidden() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_data(12u32, &BufferUsage::all(),
+        let (buffer, _) = ImmutableBuffer::from_data(12u32, BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
@@ -590,11 +590,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, _) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -609,11 +609,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, init) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -630,11 +630,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, init) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let cb1 = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -32,7 +32,7 @@ use buffer::CpuAccessibleBuffer;
 use buffer::sys::BufferCreationError;
 use buffer::sys::SparseLevel;
 use buffer::sys::UnsafeBuffer;
-use buffer::sys::Usage;
+use buffer::BufferUsage;
 use buffer::traits::BufferAccess;
 use buffer::traits::BufferInner;
 use buffer::traits::Buffer;
@@ -93,12 +93,12 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_data<'a, I>(data: T, usage: &Usage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_data<'a, I>(data: T, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
                     -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_data(queue.device(), &Usage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_data(queue.device(), &BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -109,7 +109,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_buffer<'a, B, I>(source: B, usage: &Usage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_buffer<'a, B, I>(source: B, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
                 -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), OomError>
         where B: Buffer + TypedBuffer<Content = T> + DeviceOwned,      // TODO: remove + DeviceOwned once Buffer requires it
               B::Access: 'static + Clone + Send + Sync,
@@ -140,7 +140,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     }
 
     /// Builds an `ImmutableBuffer` that copies its data from another buffer.
-    pub fn from_buffer_with_builder<'a, B, I, Cb, O>(source: B, usage: &Usage, queue_families: I,
+    pub fn from_buffer_with_builder<'a, B, I, Cb, O>(source: B, usage: &BufferUsage, queue_families: I,
                                                      builder: Cb)
                 -> Result<(Arc<ImmutableBuffer<T>>, O), ImmutableBufferFromBufferWithBuilderError>
         where B: Buffer + TypedBuffer<Content = T> + DeviceOwned,      // TODO: remove + DeviceOwned once Buffer requires it
@@ -150,7 +150,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     {
         unsafe {
             // We automatically set `transfer_dest` to true in order to avoid annoying errors.
-            let actual_usage = Usage {
+            let actual_usage = BufferUsage {
                 transfer_dest: true,
                 .. *usage
             };
@@ -182,7 +182,7 @@ impl<T> ImmutableBuffer<T> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(device: Arc<Device>, usage: &Usage, queue_families: I)
+    pub unsafe fn uninitialized<'a, I>(device: Arc<Device>, usage: &BufferUsage, queue_families: I)
                 -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -191,13 +191,13 @@ impl<T> ImmutableBuffer<T> {
 }
 
 impl<T> ImmutableBuffer<[T]> {
-    pub fn from_iter<'a, D, I>(data: D, usage: &Usage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_iter<'a, D, I>(data: D, usage: &BufferUsage, queue_families: I, queue: Arc<Queue>)
                 -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferFromBufferFuture), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               D: ExactSizeIterator<Item = T>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_iter(queue.device(), &Usage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_iter(queue.device(), &BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -219,7 +219,7 @@ impl<T> ImmutableBuffer<[T]> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(device: Arc<Device>, len: usize, usage: &Usage,
+    pub unsafe fn uninitialized_array<'a, I>(device: Arc<Device>, len: usize, usage: &BufferUsage,
                                              queue_families: I)
               -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferInitialization<[T]>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
@@ -245,7 +245,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     ///   data.
     ///
     #[inline]
-    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: &Usage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: &BufferUsage, queue_families: I)
                              -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -255,7 +255,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
 
     // Internal implementation of `raw`. This is separated from `raw` so that it doesn't need to be
     // inlined.
-    unsafe fn raw_impl(device: Arc<Device>, size: usize, usage: &Usage,
+    unsafe fn raw_impl(device: Arc<Device>, size: usize, usage: &BufferUsage,
                        queue_families: SmallVec<[u32; 4]>)
                        -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), OomError>
     {
@@ -517,7 +517,7 @@ mod tests {
     use std::iter;
     use buffer::cpu_access::CpuAccessibleBuffer;
     use buffer::immutable::ImmutableBuffer;
-    use buffer::sys::Usage;
+    use buffer::BufferUsage;
     use command_buffer::AutoCommandBufferBuilder;
     use command_buffer::CommandBuffer;
     use command_buffer::CommandBufferBuilder;
@@ -527,11 +527,11 @@ mod tests {
     fn from_data_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_data(12u32, &Usage::all(),
+        let (buffer, _) = ImmutableBuffer::from_data(12u32, &BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_data(&device, &Usage::all(),
+        let dest = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
                                                   iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -548,11 +548,11 @@ mod tests {
     fn from_iter_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_iter((0 .. 512u32).map(|n| n * 2), &Usage::all(),
+        let (buffer, _) = ImmutableBuffer::from_iter((0 .. 512u32).map(|n| n * 2), &BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_iter(&device, &Usage::all(),
+        let dest = CpuAccessibleBuffer::from_iter(&device, &BufferUsage::all(),
                                                   iter::once(queue.family()),
                                                   (0 .. 512).map(|_| 0u32)).unwrap();
 
@@ -573,7 +573,7 @@ mod tests {
     fn writing_forbidden() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let (buffer, _) = ImmutableBuffer::from_data(12u32, &Usage::all(),
+        let (buffer, _) = ImmutableBuffer::from_data(12u32, &BufferUsage::all(),
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
@@ -590,11 +590,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, _) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &Usage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &Usage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -609,11 +609,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, init) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &Usage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &Usage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -630,11 +630,11 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, init) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), &Usage::all(),
+            ImmutableBuffer::<u32>::uninitialized(device.clone(), &BufferUsage::all(),
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, &Usage::all(),
+        let src = CpuAccessibleBuffer::from_data(&device, &BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let cb1 = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -68,12 +68,12 @@ pub use self::device_local::DeviceLocalBuffer;
 pub use self::immutable::ImmutableBuffer;
 pub use self::slice::BufferSlice;
 pub use self::sys::BufferCreationError;
-pub use self::sys::Usage as BufferUsage;
 pub use self::traits::BufferAccess;
 pub use self::traits::BufferInner;
 pub use self::traits::Buffer;
 pub use self::traits::TypedBuffer;
 pub use self::traits::TypedBufferAccess;
+pub use self::usage::BufferUsage;
 pub use self::view::BufferView;
 pub use self::view::BufferViewRef;
 
@@ -86,3 +86,4 @@ pub mod view;
 
 mod slice;
 mod traits;
+mod usage;

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -64,14 +64,14 @@ impl UnsafeBuffer {
     /// Panics if `sparse.sparse` is false and `sparse.sparse_residency` or
     /// `sparse.sparse_aliased` is true.
     ///
-    pub unsafe fn new<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage,
+    pub unsafe fn new<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage,
                              sharing: Sharing<I>, sparse: SparseLevel)
                              -> Result<(UnsafeBuffer, MemoryRequirements), BufferCreationError>
         where I: Iterator<Item = u32>
     {
         let vk = device.pointers();
 
-        let usage_bits = usage_to_bits(&usage);
+        let usage_bits = usage_to_bits(usage);
 
         // Checking sparse features.
         assert!(sparse.sparse || !sparse.sparse_residency, "Can't enable sparse residency without \
@@ -384,7 +384,7 @@ mod tests {
     fn create() {
         let (device, _) = gfx_dev_and_queue!();
         let (buf, reqs) = unsafe {
-            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               SparseLevel::none())
         }.unwrap();
 
@@ -399,7 +399,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: true, sparse_aliased: false };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -410,7 +410,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: false, sparse_aliased: true };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -420,7 +420,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseBindingFeatureNotEnabled) => (),
@@ -434,7 +434,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: true, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyBufferFeatureNotEnabled) => (),
@@ -448,7 +448,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: true };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyAliasedFeatureNotEnabled) => (),

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -31,6 +31,8 @@ use std::ptr;
 use std::sync::Arc;
 use smallvec::SmallVec;
 
+use buffer::BufferUsage;
+use buffer::usage::usage_to_bits;
 use device::Device;
 use device::DeviceOwned;
 use memory::DeviceMemory;
@@ -62,14 +64,14 @@ impl UnsafeBuffer {
     /// Panics if `sparse.sparse` is false and `sparse.sparse_residency` or
     /// `sparse.sparse_aliased` is true.
     ///
-    pub unsafe fn new<'a, I>(device: &Arc<Device>, size: usize, usage: &Usage, sharing: Sharing<I>,
-                             sparse: SparseLevel)
+    pub unsafe fn new<'a, I>(device: &Arc<Device>, size: usize, usage: &BufferUsage,
+                             sharing: Sharing<I>, sparse: SparseLevel)
                              -> Result<(UnsafeBuffer, MemoryRequirements), BufferCreationError>
         where I: Iterator<Item = u32>
     {
         let vk = device.pointers();
 
-        let usage_bits = usage.to_usage_bits();
+        let usage_bits = usage_to_bits(&usage);
 
         // Checking sparse features.
         assert!(sparse.sparse || !sparse.sparse_residency, "Can't enable sparse residency without \
@@ -301,170 +303,6 @@ impl SparseLevel {
     }
 }
 
-/// Describes how a buffer is going to be used. This is **not** an optimization.
-///
-/// If you try to use a buffer in a way that you didn't declare, a panic will happen.
-///
-/// Some methods are provided to build `Usage` structs for some common situations. However
-/// there is no restriction in the combination of usages that can be enabled.
-#[derive(Debug, Copy, Clone)]
-pub struct Usage {
-    pub transfer_source: bool,
-    pub transfer_dest: bool,
-    pub uniform_texel_buffer: bool,
-    pub storage_texel_buffer: bool,
-    pub uniform_buffer: bool,
-    pub storage_buffer: bool,
-    pub index_buffer: bool,
-    pub vertex_buffer: bool,
-    pub indirect_buffer: bool,
-}
-
-impl Usage {
-    /// Builds a `Usage` with all values set to false.
-    #[inline]
-    pub fn none() -> Usage {
-        Usage {
-            transfer_source: false,
-            transfer_dest: false,
-            uniform_texel_buffer: false,
-            storage_texel_buffer: false,
-            uniform_buffer: false,
-            storage_buffer: false,
-            index_buffer: false,
-            vertex_buffer: false,
-            indirect_buffer: false,
-        }
-    }
-
-    /// Builds a `Usage` with all values set to true. Can be used for quick prototyping.
-    #[inline]
-    pub fn all() -> Usage {
-        Usage {
-            transfer_source: true,
-            transfer_dest: true,
-            uniform_texel_buffer: true,
-            storage_texel_buffer: true,
-            uniform_buffer: true,
-            storage_buffer: true,
-            index_buffer: true,
-            vertex_buffer: true,
-            indirect_buffer: true,
-        }
-    }
-
-    /// Builds a `Usage` with `transfer_source` set to true and the rest to false.
-    #[inline]
-    pub fn transfer_source() -> Usage {
-        Usage {
-            transfer_source: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `transfer_dest` set to true and the rest to false.
-    #[inline]
-    pub fn transfer_dest() -> Usage {
-        Usage {
-            transfer_dest: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `vertex_buffer` set to true and the rest to false.
-    #[inline]
-    pub fn vertex_buffer() -> Usage {
-        Usage {
-            vertex_buffer: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `vertex_buffer` and `transfer_dest` set to true and the rest to false.
-    #[inline]
-    pub fn vertex_buffer_transfer_dest() -> Usage {
-        Usage {
-            vertex_buffer: true,
-            transfer_dest: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `index_buffer` set to true and the rest to false.
-    #[inline]
-    pub fn index_buffer() -> Usage {
-        Usage {
-            index_buffer: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `index_buffer` and `transfer_dest` set to true and the rest to false.
-    #[inline]
-    pub fn index_buffer_transfer_dest() -> Usage {
-        Usage {
-            index_buffer: true,
-            transfer_dest: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `uniform_buffer` set to true and the rest to false.
-    #[inline]
-    pub fn uniform_buffer() -> Usage {
-        Usage {
-            uniform_buffer: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `uniform_buffer` and `transfer_dest` set to true and the rest
-    /// to false.
-    #[inline]
-    pub fn uniform_buffer_transfer_dest() -> Usage {
-        Usage {
-            uniform_buffer: true,
-            transfer_dest: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `indirect_buffer` set to true and the rest to false.
-    #[inline]
-    pub fn indirect_buffer() -> Usage {
-        Usage {
-            indirect_buffer: true,
-            .. Usage::none()
-        }
-    }
-
-    /// Builds a `Usage` with `indirect_buffer` and `transfer_dest` set to true and the rest
-    /// to false.
-    #[inline]
-    pub fn indirect_buffer_transfer_dest() -> Usage {
-        Usage {
-            indirect_buffer: true,
-            transfer_dest: true,
-            .. Usage::none()
-        }
-    }
-
-    #[inline]
-    fn to_usage_bits(&self) -> vk::BufferUsageFlagBits {
-        let mut result = 0;
-        if self.transfer_source { result |= vk::BUFFER_USAGE_TRANSFER_SRC_BIT; }
-        if self.transfer_dest { result |= vk::BUFFER_USAGE_TRANSFER_DST_BIT; }
-        if self.uniform_texel_buffer { result |= vk::BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT; }
-        if self.storage_texel_buffer { result |= vk::BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT; }
-        if self.uniform_buffer { result |= vk::BUFFER_USAGE_UNIFORM_BUFFER_BIT; }
-        if self.storage_buffer { result |= vk::BUFFER_USAGE_STORAGE_BUFFER_BIT; }
-        if self.index_buffer { result |= vk::BUFFER_USAGE_INDEX_BUFFER_BIT; }
-        if self.vertex_buffer { result |= vk::BUFFER_USAGE_VERTEX_BUFFER_BIT; }
-        if self.indirect_buffer { result |= vk::BUFFER_USAGE_INDIRECT_BUFFER_BIT; }
-        result
-    }
-}
-
 /// Error that can happen when creating a buffer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BufferCreationError {
@@ -536,7 +374,7 @@ mod tests {
     use super::BufferCreationError;
     use super::SparseLevel;
     use super::UnsafeBuffer;
-    use super::Usage;
+    use super::BufferUsage;
 
     use device::Device;
     use device::DeviceOwned;
@@ -546,7 +384,7 @@ mod tests {
     fn create() {
         let (device, _) = gfx_dev_and_queue!();
         let (buf, reqs) = unsafe {
-            UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               SparseLevel::none())
         }.unwrap();
 
@@ -561,7 +399,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: true, sparse_aliased: false };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -572,7 +410,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: false, sparse_aliased: true };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -582,7 +420,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseBindingFeatureNotEnabled) => (),
@@ -596,7 +434,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: true, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyBufferFeatureNotEnabled) => (),
@@ -610,7 +448,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: true };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, &Usage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(&device, 128, &BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyAliasedFeatureNotEnabled) => (),

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use vk;
+
+/// Describes how a buffer is going to be used. This is **not** an optimization.
+///
+/// If you try to use a buffer in a way that you didn't declare, a panic will happen.
+///
+/// Some methods are provided to build `BufferUsage` structs for some common situations. However
+/// there is no restriction in the combination of BufferUsages that can be enabled.
+#[derive(Debug, Copy, Clone)]
+pub struct BufferUsage {
+    pub transfer_source: bool,
+    pub transfer_dest: bool,
+    pub uniform_texel_buffer: bool,
+    pub storage_texel_buffer: bool,
+    pub uniform_buffer: bool,
+    pub storage_buffer: bool,
+    pub index_buffer: bool,
+    pub vertex_buffer: bool,
+    pub indirect_buffer: bool,
+}
+
+impl BufferUsage {
+    /// Builds a `BufferUsage` with all values set to false.
+    #[inline]
+    pub fn none() -> BufferUsage {
+        BufferUsage {
+            transfer_source: false,
+            transfer_dest: false,
+            uniform_texel_buffer: false,
+            storage_texel_buffer: false,
+            uniform_buffer: false,
+            storage_buffer: false,
+            index_buffer: false,
+            vertex_buffer: false,
+            indirect_buffer: false,
+        }
+    }
+
+    /// Builds a `BufferUsage` with all values set to true. Can be used for quick prototyping.
+    #[inline]
+    pub fn all() -> BufferUsage {
+        BufferUsage {
+            transfer_source: true,
+            transfer_dest: true,
+            uniform_texel_buffer: true,
+            storage_texel_buffer: true,
+            uniform_buffer: true,
+            storage_buffer: true,
+            index_buffer: true,
+            vertex_buffer: true,
+            indirect_buffer: true,
+        }
+    }
+
+    /// Builds a `BufferUsage` with `transfer_source` set to true and the rest to false.
+    #[inline]
+    pub fn transfer_source() -> BufferUsage {
+        BufferUsage {
+            transfer_source: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `transfer_dest` set to true and the rest to false.
+    #[inline]
+    pub fn transfer_dest() -> BufferUsage {
+        BufferUsage {
+            transfer_dest: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `vertex_buffer` set to true and the rest to false.
+    #[inline]
+    pub fn vertex_buffer() -> BufferUsage {
+        BufferUsage {
+            vertex_buffer: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `vertex_buffer` and `transfer_dest` set to true and the rest
+    /// to false.
+    #[inline]
+    pub fn vertex_buffer_transfer_dest() -> BufferUsage {
+        BufferUsage {
+            vertex_buffer: true,
+            transfer_dest: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `index_buffer` set to true and the rest to false.
+    #[inline]
+    pub fn index_buffer() -> BufferUsage {
+        BufferUsage {
+            index_buffer: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `index_buffer` and `transfer_dest` set to true and the rest to false.
+    #[inline]
+    pub fn index_buffer_transfer_dest() -> BufferUsage {
+        BufferUsage {
+            index_buffer: true,
+            transfer_dest: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `uniform_buffer` set to true and the rest to false.
+    #[inline]
+    pub fn uniform_buffer() -> BufferUsage {
+        BufferUsage {
+            uniform_buffer: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `uniform_buffer` and `transfer_dest` set to true and the rest
+    /// to false.
+    #[inline]
+    pub fn uniform_buffer_transfer_dest() -> BufferUsage {
+        BufferUsage {
+            uniform_buffer: true,
+            transfer_dest: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `indirect_buffer` set to true and the rest to false.
+    #[inline]
+    pub fn indirect_buffer() -> BufferUsage {
+        BufferUsage {
+            indirect_buffer: true,
+            .. BufferUsage::none()
+        }
+    }
+
+    /// Builds a `BufferUsage` with `indirect_buffer` and `transfer_dest` set to true and the rest
+    /// to false.
+    #[inline]
+    pub fn indirect_buffer_transfer_dest() -> BufferUsage {
+        BufferUsage {
+            indirect_buffer: true,
+            transfer_dest: true,
+            .. BufferUsage::none()
+        }
+    }
+}
+
+/// Turns a `BufferUsage` into raw bits.
+#[inline]
+pub fn usage_to_bits(usage: &BufferUsage) -> vk::BufferUsageFlagBits {
+    let mut result = 0;
+    if usage.transfer_source { result |= vk::BUFFER_USAGE_TRANSFER_SRC_BIT; }
+    if usage.transfer_dest { result |= vk::BUFFER_USAGE_TRANSFER_DST_BIT; }
+    if usage.uniform_texel_buffer { result |= vk::BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT; }
+    if usage.storage_texel_buffer { result |= vk::BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT; }
+    if usage.uniform_buffer { result |= vk::BUFFER_USAGE_UNIFORM_BUFFER_BIT; }
+    if usage.storage_buffer { result |= vk::BUFFER_USAGE_STORAGE_BUFFER_BIT; }
+    if usage.index_buffer { result |= vk::BUFFER_USAGE_INDEX_BUFFER_BIT; }
+    if usage.vertex_buffer { result |= vk::BUFFER_USAGE_VERTEX_BUFFER_BIT; }
+    if usage.indirect_buffer { result |= vk::BUFFER_USAGE_INDIRECT_BUFFER_BIT; }
+    result
+}

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::ops::BitOr;
 use vk;
 
 /// Describes how a buffer is going to be used. This is **not** an optimization.
@@ -155,6 +156,25 @@ impl BufferUsage {
             indirect_buffer: true,
             transfer_dest: true,
             .. BufferUsage::none()
+        }
+    }
+}
+
+impl BitOr for BufferUsage {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self {
+        BufferUsage {
+            transfer_source: self.transfer_source || rhs.transfer_source,
+            transfer_dest: self.transfer_dest || rhs.transfer_dest,
+            uniform_texel_buffer: self.uniform_texel_buffer || rhs.uniform_texel_buffer,
+            storage_texel_buffer: self.storage_texel_buffer || rhs.storage_texel_buffer,
+            uniform_buffer: self.uniform_buffer || rhs.uniform_buffer,
+            storage_buffer: self.storage_buffer || rhs.storage_buffer,
+            index_buffer: self.index_buffer || rhs.index_buffer,
+            vertex_buffer: self.vertex_buffer || rhs.vertex_buffer,
+            indirect_buffer: self.indirect_buffer || rhs.indirect_buffer,
         }
     }
 }

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -181,7 +181,7 @@ impl BitOr for BufferUsage {
 
 /// Turns a `BufferUsage` into raw bits.
 #[inline]
-pub fn usage_to_bits(usage: &BufferUsage) -> vk::BufferUsageFlagBits {
+pub fn usage_to_bits(usage: BufferUsage) -> vk::BufferUsageFlagBits {
     let mut result = 0;
     if usage.transfer_source { result |= vk::BUFFER_USAGE_TRANSFER_SRC_BIT; }
     if usage.transfer_dest { result |= vk::BUFFER_USAGE_TRANSFER_DST_BIT; }

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -31,7 +31,7 @@
 //!     .. BufferUsage::none()
 //! };
 //!
-//! let (buffer, _future) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|n| n), &usage,
+//! let (buffer, _future) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|n| n), usage,
 //!                                                             Some(queue.family()),
 //!                                                             queue.clone()).unwrap();
 //! let _view = BufferView::new(buffer, format::R32Uint).unwrap();
@@ -336,7 +336,7 @@ mod tests {
             .. BufferUsage::none()
         };
 
-        let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), &usage,
+        let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), usage,
                                                                   Some(queue.family()), queue.clone()).unwrap();
         let view = BufferView::new(buffer, format::R8G8B8A8Unorm).unwrap();
 
@@ -353,7 +353,7 @@ mod tests {
             .. BufferUsage::none()
         };
 
-        let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), &usage,
+        let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), usage,
                                                                   Some(queue.family()),
                                                                   queue.clone()).unwrap();
         let view = BufferView::new(buffer, format::R8G8B8A8Unorm).unwrap();
@@ -371,7 +371,7 @@ mod tests {
             .. BufferUsage::none()
         };
 
-        let (buffer, _) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|_| 0), &usage,
+        let (buffer, _) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|_| 0), usage,
                                                               Some(queue.family()),
                                                               queue.clone()).unwrap();
         let view = BufferView::new(buffer, format::R32Uint).unwrap();
@@ -386,7 +386,7 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]),
-                                                                  &BufferUsage::none(),
+                                                                  BufferUsage::none(),
                                                                   Some(queue.family()),
                                                                   queue.clone()).unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         };
 
         let (buffer, _) = ImmutableBuffer::<[[f64; 4]]>::from_iter((0..128).map(|_| [0.0; 4]),
-                                                                   &usage, Some(queue.family()),
+                                                                   usage, Some(queue.family()),
                                                                    queue.clone()).unwrap();
 
         // TODO: what if R64G64B64A64Sfloat is supported?

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -20,15 +20,15 @@
 //! ```
 //! # use std::sync::Arc;
 //! use vulkano::buffer::immutable::ImmutableBuffer;
-//! use vulkano::buffer::sys::Usage;
+//! use vulkano::buffer::BufferUsage;
 //! use vulkano::buffer::BufferView;
 //! use vulkano::format;
 //!
 //! # let device: Arc<vulkano::device::Device> = return;
 //! # let queue: Arc<vulkano::device::Queue> = return;
-//! let usage = Usage {
+//! let usage = BufferUsage {
 //!     storage_texel_buffer: true,
-//!     .. Usage::none()
+//!     .. BufferUsage::none()
 //! };
 //!
 //! let (buffer, _future) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|n| n), &usage,
@@ -321,7 +321,7 @@ impl From<Error> for BufferViewCreationError {
 #[cfg(test)]
 mod tests {
     use buffer::BufferView;
-    use buffer::sys::Usage;
+    use buffer::BufferUsage;
     use buffer::view::BufferViewCreationError;
     use buffer::immutable::ImmutableBuffer;
     use format;
@@ -331,9 +331,9 @@ mod tests {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, queue) = gfx_dev_and_queue!();
 
-        let usage = Usage {
+        let usage = BufferUsage {
             uniform_texel_buffer: true,
-            .. Usage::none()
+            .. BufferUsage::none()
         };
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), &usage,
@@ -348,9 +348,9 @@ mod tests {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, queue) = gfx_dev_and_queue!();
 
-        let usage = Usage {
+        let usage = BufferUsage {
             storage_texel_buffer: true,
-            .. Usage::none()
+            .. BufferUsage::none()
         };
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), &usage,
@@ -366,9 +366,9 @@ mod tests {
         // `VK_FORMAT_R32_UINT` guaranteed to be a supported format for atomics
         let (device, queue) = gfx_dev_and_queue!();
 
-        let usage = Usage {
+        let usage = BufferUsage {
             storage_texel_buffer: true,
-            .. Usage::none()
+            .. BufferUsage::none()
         };
 
         let (buffer, _) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|_| 0), &usage,
@@ -386,7 +386,7 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]),
-                                                                  &Usage::none(),
+                                                                  &BufferUsage::none(),
                                                                   Some(queue.family()),
                                                                   queue.clone()).unwrap();
 
@@ -400,10 +400,10 @@ mod tests {
     fn unsupported_format() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let usage = Usage {
+        let usage = BufferUsage {
             uniform_texel_buffer: true,
             storage_texel_buffer: true,
-            .. Usage::none()
+            .. BufferUsage::none()
         };
 
         let (buffer, _) = ImmutableBuffer::<[[f64; 4]]>::from_iter((0..128).map(|_| [0.0; 4]),

--- a/vulkano/src/command_buffer/commands_raw/fill_buffer.rs
+++ b/vulkano/src/command_buffer/commands_raw/fill_buffer.rs
@@ -144,7 +144,7 @@ mod tests {
     fn basic() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let buffer = CpuAccessibleBuffer::from_data(&device, &BufferUsage::transfer_dest(),
+        let buffer = CpuAccessibleBuffer::from_data(&device, BufferUsage::transfer_dest(),
                                                     Some(queue.family()), 0u32).unwrap();
 
         let _ = PrimaryCbBuilder::new(&device, queue.family())

--- a/vulkano/src/pipeline/vertex.rs
+++ b/vulkano/src/pipeline/vertex.rs
@@ -39,7 +39,7 @@
 //! # use vulkano::device::Device;
 //! # use vulkano::device::Queue;
 //! use vulkano::buffer::BufferAccess;
-//! use vulkano::buffer::Usage as BufferUsage;
+//! use vulkano::buffer::BufferUsage;
 //! use vulkano::memory::HostVisible;
 //! use vulkano::pipeline::vertex::;
 //! # let device: Arc<Device> = return;


### PR DESCRIPTION
The main change is that all functions that were taking a `&BufferUsage` now take a `BufferUsage` by value.