### PR TITLE
Change futures to chain futures between frames

### DIFF
--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -55,6 +55,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::viewport::Scissor;
 use vulkano::swapchain::SurfaceTransform;
 use vulkano::swapchain::Swapchain;
+use vulkano::sync::now;
 use vulkano::sync::GpuFuture;
 
 use std::sync::Arc;
@@ -348,15 +349,15 @@ fn main() {
     // they are in use by the GPU.
     //
     // Destroying the `GpuFuture` blocks until the GPU is finished executing it. In order to avoid
-    // that, we store them in a `Vec` and clean them from time to time.
-    let mut submissions: Vec<Box<GpuFuture>> = Vec::new();
+    // that, we store the submission of the previous frame here.
+    let mut previous_frame_end = Box::new(now(device.clone())) as Box<GpuFuture>;
 
     loop {
-        // Clearing the old submissions by keeping alive only the ones which probably aren't
-        // finished.
-        while submissions.len() >= 4 {
-            submissions.remove(0);
-        }
+        // It is important to call this function from time to time, otherwise resources will keep
+        // accumulating and you will eventually reach an out of memory error.
+        // Calling this function polls various fences in order to determine what the GPU has
+        // already processed, and frees the resources that are no longer needed.
+        previous_frame_end.cleanup_finished();
 
         // Before we can draw on the output, we have to *acquire* an image from the swapchain. If
         // no image is available (which happens if you submit draw commands too quickly), then the
@@ -365,7 +366,7 @@ fn main() {
         //
         // This function can block if no image is available. The parameter is a timeout after
         // which the function call will return an error.
-        let (image_num, future) = swapchain.acquire_next_image(Duration::new(1, 0)).unwrap();
+        let (image_num, acquire_future) = swapchain.acquire_next_image(Duration::new(1, 0)).unwrap();
 
         // In order to draw, we have to build a *command buffer*. The command buffer object holds
         // the list of commands that are going to be executed.
@@ -404,7 +405,7 @@ fn main() {
             // Finish building the command buffer by calling `build`.
             .build().unwrap();
 
-        let future = future
+        let future = previous_frame_end.join(acquire_future)
             .then_execute(queue.clone(), command_buffer).unwrap()
 
             // The color output is now expected to contain our triangle. But in order to show it on
@@ -415,7 +416,7 @@ fn main() {
             // the GPU has finished executing the command buffer that draws the triangle.
             .then_swapchain_present(queue.clone(), swapchain.clone(), image_num)
             .then_signal_fence_and_flush().unwrap();
-        submissions.push(Box::new(future) as Box<_>);
+        previous_frame_end = Box::new(future) as Box<_>;
 
         // Note that in more complex programs it is likely that one of `acquire_next_image`,
         // `command_buffer::submit`, or `present` will block for some time. This happens when the

--- a/vulkano/src/command_buffer/cb/submit_sync.rs
+++ b/vulkano/src/command_buffer/cb/submit_sync.rs
@@ -787,6 +787,8 @@ unsafe impl<I> CommandBuffer for SubmitSyncLayer<I> where I: CommandBuffer {
                         Err(err) => err
                     };
 
+                    // FIXME: this is bad because dropping the submit sync layer doesn't drop the
+                    //        attachments of the framebuffer, meaning that they will stay locked
                     match (img.try_gpu_lock(entry.exclusive, queue), prev_err) {
                         (Ok(_), _) => (),
                         (Err(err), AccessCheckError::Unknown) => return Err(err.into()),

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -238,6 +238,8 @@ unsafe impl<F, A> ImageAccess for AttachmentImageAccess<F, A>
     #[inline]
     fn try_gpu_lock(&self, _: bool, _: &Queue) -> Result<(), AccessError> {
         // FIXME: uncomment when it's working
+        //        the problem is in the submit sync layer which locks framebuffer attachments and
+        //        keeps them locked even after destruction
         Ok(())
         /*if self.already_locked.swap(true, Ordering::SeqCst) == true {
             return false;
@@ -249,6 +251,8 @@ unsafe impl<F, A> ImageAccess for AttachmentImageAccess<F, A>
     #[inline]
     unsafe fn increase_gpu_lock(&self) {
         // FIXME: uncomment when it's working
+        //        the problem is in the submit sync layer which locks framebuffer attachments and
+        //        keeps them locked even after destruction
         /*debug_assert!(self.already_locked.load(Ordering::SeqCst));
         let val = self.img.gpu_lock.fetch_add(1, Ordering::SeqCst);
         debug_assert!(val >= 1);*/

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -703,14 +703,16 @@ unsafe impl<P> GpuFuture for PresentFuture<P> where P: GpuFuture {
     fn check_buffer_access(&self, buffer: &BufferAccess, exclusive: bool, queue: &Queue)
                            -> Result<Option<(PipelineStages, AccessFlagBits)>, AccessCheckError>
     {
-        unimplemented!()        // TODO: VK specs don't say whether it is legal to do that
+        self.previous.check_buffer_access(buffer, exclusive, queue)
     }
 
     #[inline]
     fn check_image_access(&self, image: &ImageAccess, layout: ImageLayout, exclusive: bool, queue: &Queue)
                           -> Result<Option<(PipelineStages, AccessFlagBits)>, AccessCheckError>
     {
-        unimplemented!()        // TODO: VK specs don't say whether it is legal to do that
+        // FIXME: must return `Err(SwapchainImageAcquireOnly)` for the swapchain image that is
+        //        being presented
+        self.previous.check_image_access(image, layout, exclusive, queue)
     }
 }
 

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -58,7 +58,9 @@ pub unsafe trait GpuFuture: DeviceOwned {
     ///
     /// It is the responsibility of the caller to ensure that the submission is going to be
     /// submitted only once. However keep in mind that this function can perfectly be called
-    /// multiple times (as long as the returned object is only submitted once).
+    /// multiple times (as long as the returned object is only submitted once). 
+    /// Also note that calling `flush()` on the future  may change the value returned by
+    /// `build_submission()`.
     ///
     /// It is however the responsibility of the implementation to not return the same submission
     /// from multiple different future objects. For example if you implement `GpuFuture` on
@@ -197,9 +199,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
     /// > function. If so, consider using `then_signal_fence_and_flush`.
     #[inline]
     fn then_signal_fence(self) -> FenceSignalFuture<Self> where Self: Sized {
-        fence_signal::then_signal_fence(self, FenceSignalFutureBehavior::Block {
-            timeout: None
-        })
+        fence_signal::then_signal_fence(self, FenceSignalFutureBehavior::Continue)
     }
 
     /// Signals a fence after this future. Returns another future that represents the signal.


### PR DESCRIPTION
Right now what all the examples do is submit a command buffer, then add the future to a list. Each submission and each future is independant.

This means that we have no way to know that two frames don't get drawn simultaneously. This is problematic, because for example if you want to use the same depth buffer for each frame then vulkano will return an error as it has no way to know that the depth buffer is not being written multiple times simultaneously.

This PR changes this design. What is now idiomatic is to manipulate only one future, and submit each new future after the previous frame's future. This has always been the intended design, but up until now it wasn't implemented properly.
