### PR TITLE
Turn all the constructor that take a &Arc<Device> to Arc<Device>

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -100,7 +100,7 @@ fn main() {
     // Create an image in order to generate some additional logging:
     let pixel_format = Format::R8G8B8A8Uint;
     let dimensions = Dimensions::Dim2d { width: 4096, height: 4096 };
-    ImmutableImage::new(&device, dimensions, pixel_format, Some(queue.family())).unwrap();
+    ImmutableImage::new(device.clone(), dimensions, pixel_format, Some(queue.family())).unwrap();
 
     // (At this point you should see a bunch of messages printed to the terminal window - have fun debugging!)
 }

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -56,7 +56,7 @@ fn main() {
         let present = caps.present_modes.iter().next().unwrap();
         let usage = caps.supported_usage_flags;
 
-        vulkano::swapchain::Swapchain::new(&device, &window.surface(), caps.min_image_count,
+        vulkano::swapchain::Swapchain::new(device.clone(), &window.surface(), caps.min_image_count,
                                            vulkano::format::B8G8R8A8Srgb, dimensions, 1,
                                            usage, &queue, vulkano::swapchain::SurfaceTransform::Identity,
                                            vulkano::swapchain::CompositeAlpha::Opaque,
@@ -69,7 +69,7 @@ fn main() {
     impl_vertex!(Vertex, position);
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer::<[Vertex]>
-                               ::from_iter(&device, vulkano::buffer::BufferUsage::all(),
+                               ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(),
                                        Some(queue.family()), [
                                            Vertex { position: [-0.5, -0.5 ] },
                                            Vertex { position: [-0.5,  0.5 ] },
@@ -99,7 +99,7 @@ fn main() {
         ).unwrap()
     );
 
-    let texture = vulkano::image::immutable::ImmutableImage::new(&device, vulkano::image::Dimensions::Dim2d { width: 93, height: 93 },
+    let texture = vulkano::image::immutable::ImmutableImage::new(device.clone(), vulkano::image::Dimensions::Dim2d { width: 93, height: 93 },
                                                                  vulkano::format::R8G8B8A8Unorm, Some(queue.family())).unwrap();
 
 
@@ -112,20 +112,20 @@ fn main() {
 
         // TODO: staging buffer instead
         vulkano::buffer::cpu_access::CpuAccessibleBuffer::<[[u8; 4]]>
-            ::from_iter(&device, vulkano::buffer::BufferUsage::all(),
+            ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(),
                         Some(queue.family()), image_data_chunks)
                         .expect("failed to create buffer")
     };
 
 
-    let sampler = vulkano::sampler::Sampler::new(&device, vulkano::sampler::Filter::Linear,
+    let sampler = vulkano::sampler::Sampler::new(device.clone(), vulkano::sampler::Filter::Linear,
                                                  vulkano::sampler::Filter::Linear, vulkano::sampler::MipmapMode::Nearest,
                                                  vulkano::sampler::SamplerAddressMode::Repeat,
                                                  vulkano::sampler::SamplerAddressMode::Repeat,
                                                  vulkano::sampler::SamplerAddressMode::Repeat,
                                                  0.0, 1.0, 0.0, 0.0).unwrap();
 
-    let pipeline = Arc::new(vulkano::pipeline::GraphicsPipeline::new(&device, vulkano::pipeline::GraphicsPipelineParams {
+    let pipeline = Arc::new(vulkano::pipeline::GraphicsPipeline::new(device.clone(), vulkano::pipeline::GraphicsPipelineParams {
         vertex_input: vulkano::pipeline::vertex::SingleBufferDefinition::new(),
         vertex_shader: vs.main_entry_point(),
         input_assembly: vulkano::pipeline::input_assembly::InputAssembly {

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -62,25 +62,25 @@ fn main() {
         let usage = caps.supported_usage_flags;
         let format = caps.supported_formats[0].0;
 
-        vulkano::swapchain::Swapchain::new(&device, &window.surface(), caps.min_image_count, format, dimensions, 1,
+        vulkano::swapchain::Swapchain::new(device.clone(), &window.surface(), caps.min_image_count, format, dimensions, 1,
                                            usage, &queue, vulkano::swapchain::SurfaceTransform::Identity,
                                            vulkano::swapchain::CompositeAlpha::Opaque,
                                            present, true, None).expect("failed to create swapchain")
     };
 
 
-    let depth_buffer = vulkano::image::attachment::AttachmentImage::transient(&device, images[0].dimensions(), vulkano::format::D16Unorm).unwrap().access();
+    let depth_buffer = vulkano::image::attachment::AttachmentImage::transient(device.clone(), images[0].dimensions(), vulkano::format::D16Unorm).unwrap().access();
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     let normals_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::NORMALS.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::NORMALS.iter().cloned())
                                 .expect("failed to create buffer");
 
     let index_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::INDICES.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::INDICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     // note: this teapot was meant for OpenGL where the origin is at the lower left
@@ -90,7 +90,7 @@ fn main() {
     let scale = cgmath::Matrix4::from_scale(0.01);
 
     let uniform_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer::<vs::ty::Data>
-                               ::from_data(&device, vulkano::buffer::BufferUsage::all(), Some(queue.family()), 
+                               ::from_data(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), 
                                 vs::ty::Data {
                                     world : <cgmath::Matrix4<f32> as cgmath::SquareMatrix>::identity().into(),
                                     view : (view * scale).into(),
@@ -124,7 +124,7 @@ fn main() {
         ).unwrap()
     );
 
-    let pipeline = Arc::new(vulkano::pipeline::GraphicsPipeline::new(&device, vulkano::pipeline::GraphicsPipelineParams {
+    let pipeline = Arc::new(vulkano::pipeline::GraphicsPipeline::new(device.clone(), vulkano::pipeline::GraphicsPipelineParams {
         vertex_input: vulkano::pipeline::vertex::TwoBuffersDefinition::new(),
         vertex_shader: vs.main_entry_point(),
         input_assembly: vulkano::pipeline::input_assembly::InputAssembly::triangle_list(),

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -184,7 +184,7 @@ fn main() {
         let format = caps.supported_formats[0].0;
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
-        Swapchain::new(&device, &window.surface(), caps.min_image_count, format, dimensions, 1,
+        Swapchain::new(device.clone(), &window.surface(), caps.min_image_count, format, dimensions, 1,
                        caps.supported_usage_flags, &queue, SurfaceTransform::Identity, alpha,
                        present, true, None).expect("failed to create swapchain")
     };
@@ -195,7 +195,7 @@ fn main() {
         struct Vertex { position: [f32; 2] }
         impl_vertex!(Vertex, position);
 
-        CpuAccessibleBuffer::from_iter(&device, BufferUsage::all(), Some(queue.family()), [
+        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), Some(queue.family()), [
             Vertex { position: [-0.5, -0.25] },
             Vertex { position: [0.0, 0.5] },
             Vertex { position: [0.25, -0.1] }
@@ -260,7 +260,7 @@ fn main() {
 
     // Before we draw we have to create what is called a pipeline. This is similar to an OpenGL
     // program, but much more specific.
-    let pipeline = Arc::new(GraphicsPipeline::new(&device, GraphicsPipelineParams {
+    let pipeline = Arc::new(GraphicsPipeline::new(device.clone(), GraphicsPipelineParams {
         // We need to indicate the layout of the vertices.
         // The type `SingleBufferDefinition` actually contains a template parameter corresponding
         // to the type of each vertex. But in this code it is automatically inferred.

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -78,7 +78,7 @@ impl<T> CpuAccessibleBuffer<T> {
     /// Deprecated. Use `from_data` instead.
     #[deprecated]
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -88,7 +88,7 @@ impl<T> CpuAccessibleBuffer<T> {
     }
 
     /// Builds a new buffer with some data in it. Only allowed for sized data.
-    pub fn from_data<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I, data: T)
+    pub fn from_data<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I, data: T)
                             -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: Content + 'static,
@@ -113,7 +113,7 @@ impl<T> CpuAccessibleBuffer<T> {
 
     /// Builds a new uninitialized buffer. Only allowed for sized data.
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
+    pub unsafe fn uninitialized<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I)
                                        -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -124,7 +124,7 @@ impl<T> CpuAccessibleBuffer<T> {
 impl<T> CpuAccessibleBuffer<[T]> {
     /// Builds a new buffer that contains an array `T`. The initial data comes from an iterator
     /// that produces that list of Ts.
-    pub fn from_iter<'a, I, Q>(device: &Arc<Device>, usage: BufferUsage, queue_families: Q, data: I)
+    pub fn from_iter<'a, I, Q>(device: Arc<Device>, usage: BufferUsage, queue_families: Q, data: I)
                                -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: ExactSizeIterator<Item = T>,
               T: Content + 'static,
@@ -155,7 +155,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
     // TODO: remove
     #[inline]
     #[deprecated]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
+    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -166,7 +166,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
 
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage,
+    pub unsafe fn uninitialized_array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage,
                                              queue_families: I)
                                              -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
@@ -182,7 +182,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
                              -> Result<Arc<CpuAccessibleBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -196,7 +196,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device, size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other
@@ -209,7 +209,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                            .filter(|t| t.is_host_visible())
                            .next().unwrap();    // Vk specs guarantee that this can't fail
 
-        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(&device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Linear));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         debug_assert!(mem.mapped_memory().is_some());

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -266,7 +266,7 @@ impl<T, A> CpuBufferPool<T, A> where A: MemoryPool {
                     None => return Err(OomError::OutOfDeviceMemory),
                 };
 
-                match UnsafeBuffer::new(&self.device, total_size, self.usage, sharing, SparseLevel::none()) {
+                match UnsafeBuffer::new(self.device.clone(), total_size, self.usage, sharing, SparseLevel::none()) {
                     Ok(b) => b,
                     Err(BufferCreationError::OomError(err)) => return Err(err),
                     Err(_) => unreachable!()        // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -64,7 +64,7 @@ pub struct DeviceLocalBuffer<T: ?Sized, A = Arc<StdMemoryPool>> where A: MemoryP
 impl<T> DeviceLocalBuffer<T> {
     /// Builds a new buffer. Only allowed for sized data.
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, usage: BufferUsage, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -77,7 +77,7 @@ impl<T> DeviceLocalBuffer<T> {
 impl<T> DeviceLocalBuffer<[T]> {
     /// Builds a new buffer. Can be used for arrays.
     #[inline]
-    pub fn array<'a, I>(device: &Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
+    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
                       -> Result<Arc<DeviceLocalBuffer<[T]>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -94,7 +94,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
     ///
     /// You must ensure that the size that you pass is correct for `T`.
     ///
-    pub unsafe fn raw<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
+    pub unsafe fn raw<'a, I>(device: Arc<Device>, size: usize, usage: BufferUsage, queue_families: I)
                              -> Result<Arc<DeviceLocalBuffer<T>>, OomError>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -108,7 +108,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device, size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other
@@ -125,7 +125,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(&device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Linear));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         try!(buffer.bind_memory(mem.memory(), mem.offset()));

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -99,7 +99,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
         where I: IntoIterator<Item = QueueFamily<'a>>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_data(queue.device(), BufferUsage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_data(queue.device().clone(), BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -198,7 +198,7 @@ impl<T> ImmutableBuffer<[T]> {
               D: ExactSizeIterator<Item = T>,
               T: 'static + Send + Sync + Sized,
     {
-        let source = CpuAccessibleBuffer::from_iter(queue.device(), BufferUsage::transfer_source(),
+        let source = CpuAccessibleBuffer::from_iter(queue.device().clone(), BufferUsage::transfer_source(),
                                                     iter::once(queue.family()), data)?;
         ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
     }
@@ -267,7 +267,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(&device, size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
                 Ok(b) => b,
                 Err(BufferCreationError::OomError(err)) => return Err(err),
                 Err(_) => unreachable!()        // We don't use sparse binding, therefore the other
@@ -536,7 +536,7 @@ mod tests {
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
+        let dest = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(),
                                                   iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -557,7 +557,7 @@ mod tests {
                                                      iter::once(queue.family()),
                                                      queue.clone()).unwrap();
 
-        let dest = CpuAccessibleBuffer::from_iter(&device, BufferUsage::all(),
+        let dest = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
                                                   iter::once(queue.family()),
                                                   (0 .. 512).map(|_| 0u32)).unwrap();
 
@@ -599,7 +599,7 @@ mod tests {
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -618,7 +618,7 @@ mod tests {
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let _ = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()
@@ -639,7 +639,7 @@ mod tests {
                                                   iter::once(queue.family())).unwrap()
         };
 
-        let src = CpuAccessibleBuffer::from_data(&device, BufferUsage::all(),
+        let src = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(),
                                                  iter::once(queue.family()), 0).unwrap();
 
         let cb1 = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -64,7 +64,7 @@ impl UnsafeBuffer {
     /// Panics if `sparse.sparse` is false and `sparse.sparse_residency` or
     /// `sparse.sparse_aliased` is true.
     ///
-    pub unsafe fn new<'a, I>(device: &Arc<Device>, size: usize, usage: BufferUsage,
+    pub unsafe fn new<'a, I>(device: Arc<Device>, size: usize, usage: BufferUsage,
                              sharing: Sharing<I>, sparse: SparseLevel)
                              -> Result<(UnsafeBuffer, MemoryRequirements), BufferCreationError>
         where I: Iterator<Item = u32>
@@ -384,7 +384,7 @@ mod tests {
     fn create() {
         let (device, _) = gfx_dev_and_queue!();
         let (buf, reqs) = unsafe {
-            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(device.clone(), 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               SparseLevel::none())
         }.unwrap();
 
@@ -399,7 +399,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: true, sparse_aliased: false };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -410,7 +410,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: false, sparse_residency: false, sparse_aliased: true };
         let _ = unsafe {
-            UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            UnsafeBuffer::new(device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                               sparse)
         };
     }
@@ -420,7 +420,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseBindingFeatureNotEnabled) => (),
@@ -434,7 +434,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: true, sparse_aliased: false };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyBufferFeatureNotEnabled) => (),
@@ -448,7 +448,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!(sparse_binding);
         let sparse = SparseLevel { sparse: true, sparse_residency: false, sparse_aliased: true };
         unsafe {
-            match UnsafeBuffer::new(&device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
+            match UnsafeBuffer::new(device, 128, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>,
                                     sparse)
             {
                 Err(BufferCreationError::SparseResidencyAliasedFeatureNotEnabled) => (),

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -547,7 +547,7 @@ impl UnsafeDescriptorSet {
     ///   command buffer contains a pointer/reference to a descriptor set, it is illegal to write
     ///   to it.
     ///
-    pub unsafe fn write<I>(&mut self, device: &Arc<Device>, writes: I)
+    pub unsafe fn write<I>(&mut self, device: &Device, writes: I)
         where I: Iterator<Item = DescriptorWrite>
     {
         let vk = device.pointers();

--- a/vulkano/src/descriptor/pipeline_layout/empty.rs
+++ b/vulkano/src/descriptor/pipeline_layout/empty.rs
@@ -23,7 +23,7 @@ use descriptor::pipeline_layout::PipelineLayoutDescPcRange;
 /// use vulkano::descriptor::pipeline_layout::PipelineLayoutDesc;
 /// 
 /// # let device: Arc<Device> = return;
-/// let pipeline_layout = EmptyPipelineDesc.build(&device).unwrap(); 
+/// let pipeline_layout = EmptyPipelineDesc.build(device.clone()).unwrap(); 
 /// ```
 #[derive(Debug, Copy, Clone)]
 pub struct EmptyPipelineDesc;

--- a/vulkano/src/descriptor/pipeline_layout/sys.rs
+++ b/vulkano/src/descriptor/pipeline_layout/sys.rs
@@ -48,7 +48,7 @@ impl<L> PipelineLayout<L> where L: PipelineLayoutDesc {
     /// - Panics if one of the layout returned by `provided_set_layout()` belongs to a different
     ///   device than the one passed as parameter.
     #[inline]
-    pub fn new(device: &Arc<Device>, desc: L)
+    pub fn new(device: Arc<Device>, desc: L)
                -> Result<PipelineLayout<L>, PipelineLayoutCreationError>
     {
         let vk = device.pointers();

--- a/vulkano/src/descriptor/pipeline_layout/traits.rs
+++ b/vulkano/src/descriptor/pipeline_layout/traits.rs
@@ -99,7 +99,7 @@ pub unsafe trait PipelineLayoutDesc {
     ///
     /// > **Note**: This is just a shortcut for `PipelineLayout::new`.
     #[inline]
-    fn build(self, device: &Arc<Device>)
+    fn build(self, device: Arc<Device>)
              -> Result<PipelineLayout<Self>, PipelineLayoutCreationError>
         where Self: Sized
     {

--- a/vulkano/src/device.rs
+++ b/vulkano/src/device.rs
@@ -350,7 +350,7 @@ impl Device {
         }
 
         // The weak pointer is empty, so we create the pool.
-        let new_pool = StdMemoryPool::new(me);
+        let new_pool = StdMemoryPool::new(me.clone());
         *pool = Arc::downgrade(&new_pool);
         new_pool
     }

--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -184,7 +184,7 @@ mod tests {
             }
         ).unwrap();
 
-        let img = AttachmentImage::new(&device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
+        let img = AttachmentImage::new(device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
         
         ensure_image_view_compatible(&rp, 0, &img.access()).unwrap();
     }
@@ -208,7 +208,7 @@ mod tests {
             }
         ).unwrap();
 
-        let img = AttachmentImage::new(&device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
+        let img = AttachmentImage::new(device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
         
         match ensure_image_view_compatible(&rp, 0, &img.access()) {
             Err(IncompatibleRenderPassAttachmentError::FormatMismatch {
@@ -223,7 +223,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let rp = EmptySinglePassRenderPassDesc;
-        let img = AttachmentImage::new(&device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
+        let img = AttachmentImage::new(device, [128, 128], Format::R8G8B8A8Unorm).unwrap();
         
         let _ = ensure_image_view_compatible(&rp, 0, &img.access());
     }

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -51,7 +51,7 @@ impl<F> ImmutableImage<F> {
     /// Builds a new immutable image.
     // TODO: one mipmap is probably not a great default
     #[inline]
-    pub fn new<'a, I>(device: &Arc<Device>, dimensions: Dimensions, format: F, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, dimensions: Dimensions, format: F, queue_families: I)
                       -> Result<Arc<ImmutableImage<F>>, ImageCreationError>
         where F: FormatDesc, I: IntoIterator<Item = QueueFamily<'a>>
     {
@@ -59,7 +59,7 @@ impl<F> ImmutableImage<F> {
     }
 
     /// Builds a new immutable image with the given number of mipmaps.
-    pub fn with_mipmaps<'a, I, M>(device: &Arc<Device>, dimensions: Dimensions, format: F,
+    pub fn with_mipmaps<'a, I, M>(device: Arc<Device>, dimensions: Dimensions, format: F,
                                   mipmaps: M, queue_families: I)
                                   -> Result<Arc<ImmutableImage<F>>, ImageCreationError>
         where F: FormatDesc, I: IntoIterator<Item = QueueFamily<'a>>, M: Into<MipmapsCount>
@@ -81,7 +81,7 @@ impl<F> ImmutableImage<F> {
                 Sharing::Exclusive
             };
 
-            try!(UnsafeImage::new(device, usage, format.format(), dimensions.to_image_dimensions(),
+            try!(UnsafeImage::new(device.clone(), usage, format.format(), dimensions.to_image_dimensions(),
                                   1, mipmaps, sharing, false, false))
         };
 
@@ -94,7 +94,7 @@ impl<F> ImmutableImage<F> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(&device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Optimal));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe { try!(image.bind_memory(mem.memory(), mem.offset())); }

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -68,7 +68,7 @@ pub struct StorageImage<F, A = Arc<StdMemoryPool>> where A: MemoryPool {
 
 impl<F> StorageImage<F> {
     /// Creates a new image with the given dimensions and format.
-    pub fn new<'a, I>(device: &Arc<Device>, dimensions: Dimensions, format: F, queue_families: I)
+    pub fn new<'a, I>(device: Arc<Device>, dimensions: Dimensions, format: F, queue_families: I)
                       -> Result<Arc<StorageImage<F>>, ImageCreationError>
         where F: FormatDesc,
                  I: IntoIterator<Item = QueueFamily<'a>>
@@ -102,7 +102,7 @@ impl<F> StorageImage<F> {
                 Sharing::Exclusive
             };
 
-            try!(UnsafeImage::new(device, usage, format.format(), dimensions.to_image_dimensions(),
+            try!(UnsafeImage::new(device.clone(), usage, format.format(), dimensions.to_image_dimensions(),
                                   1, 1, Sharing::Exclusive::<Empty<u32>>, false, false))
         };
 
@@ -115,7 +115,7 @@ impl<F> StorageImage<F> {
             device_local.chain(any).next().unwrap()
         };
 
-        let mem = try!(MemoryPool::alloc(&Device::standard_pool(device), mem_ty,
+        let mem = try!(MemoryPool::alloc(&Device::standard_pool(&device), mem_ty,
                                          mem_reqs.size, mem_reqs.alignment, AllocLayout::Optimal));
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe { try!(image.bind_memory(mem.memory(), mem.offset())); }
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn create() {
         let (device, queue) = gfx_dev_and_queue!();
-        let _img = StorageImage::new(&device, Dimensions::Dim2d { width: 32, height: 32 },
+        let _img = StorageImage::new(device, Dimensions::Dim2d { width: 32, height: 32 },
                                      Format::R8G8B8A8Unorm, Some(queue.family())).unwrap();
     }
 }

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -79,7 +79,7 @@ impl UnsafeImage {
     /// - Panics if the number of samples is 0.
     ///
     #[inline]
-    pub unsafe fn new<'a, Mi, I>(device: &Arc<Device>, usage: ImageUsage, format: Format,
+    pub unsafe fn new<'a, Mi, I>(device: Arc<Device>, usage: ImageUsage, format: Format,
                                  dimensions: ImageDimensions, num_samples: u32, mipmaps: Mi,
                                  sharing: Sharing<I>, linear_tiling: bool,
                                  preinitialized_layout: bool)
@@ -96,7 +96,7 @@ impl UnsafeImage {
     }
 
     // Non-templated version to avoid inlining and improve compile times.
-    unsafe fn new_impl(device: &Arc<Device>, usage: ImageUsage, format: Format,
+    unsafe fn new_impl(device: Arc<Device>, usage: ImageUsage, format: Format,
                        dimensions: ImageDimensions, num_samples: u32, mipmaps: MipmapsCount,
                        (sh_mode, sh_indices): (vk::SharingMode, SmallVec<[u32; 8]>),
                        linear_tiling: bool, preinitialized_layout: bool)
@@ -452,7 +452,7 @@ impl UnsafeImage {
     /// Creates an image from a raw handle. The image won't be destroyed.
     ///
     /// This function is for example used at the swapchain's initialization.
-    pub unsafe fn from_raw(device: &Arc<Device>, handle: u64, usage: u32, format: Format,
+    pub unsafe fn from_raw(device: Arc<Device>, handle: u64, usage: u32, format: Format,
                            dimensions: ImageDimensions, samples: u32, mipmaps: u32)
                            -> UnsafeImage
     {
@@ -996,7 +996,7 @@ mod tests {
         };
 
         let (_img, _) = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1014,7 +1014,7 @@ mod tests {
         };
 
         let (_img, _) = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1031,7 +1031,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 0, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1053,7 +1053,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 5, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1075,7 +1075,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, 0,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1098,7 +1098,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, u32::MAX,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1123,7 +1123,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 2, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1146,7 +1146,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::ASTC_5x4UnormBlock,
+            UnsafeImage::new(device, usage, Format::ASTC_5x4UnormBlock,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, u32::MAX,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1170,7 +1170,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 32, array_layers: 1,
                                                       cubemap_compatible: false }, 1, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)
@@ -1192,7 +1192,7 @@ mod tests {
         };
 
         let res = unsafe {
-            UnsafeImage::new(&device, usage, Format::R8G8B8A8Unorm,
+            UnsafeImage::new(device, usage, Format::R8G8B8A8Unorm,
                              ImageDimensions::Dim2d { width: 32, height: 64, array_layers: 1,
                                                       cubemap_compatible: true }, 1, 1,
                              Sharing::Exclusive::<Empty<_>>, false, false)

--- a/vulkano/src/memory/pool/host_visible.rs
+++ b/vulkano/src/memory/pool/host_visible.rs
@@ -36,7 +36,7 @@ impl StdHostVisibleMemoryTypePool {
     /// - Panics if the `device` and `memory_type` don't belong to the same physical device.
     ///
     #[inline]
-    pub fn new(device: &Arc<Device>, memory_type: MemoryType)
+    pub fn new(device: Arc<Device>, memory_type: MemoryType)
                -> Arc<StdHostVisibleMemoryTypePool>
     {
         assert_eq!(&**device.physical_device().instance() as *const Instance,

--- a/vulkano/src/memory/pool/non_host_visible.rs
+++ b/vulkano/src/memory/pool/non_host_visible.rs
@@ -35,7 +35,7 @@ impl StdNonHostVisibleMemoryTypePool {
     /// - Panics if the `device` and `memory_type` don't belong to the same physical device.
     ///
     #[inline]
-    pub fn new(device: &Arc<Device>, memory_type: MemoryType)
+    pub fn new(device: Arc<Device>, memory_type: MemoryType)
                -> Arc<StdNonHostVisibleMemoryTypePool>
     {
         assert_eq!(&**device.physical_device().instance() as *const Instance,

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -38,7 +38,7 @@ pub struct StdMemoryPool {
 impl StdMemoryPool {
     /// Creates a new pool.
     #[inline]
-    pub fn new(device: &Arc<Device>) -> Arc<StdMemoryPool> {
+    pub fn new(device: Arc<Device>) -> Arc<StdMemoryPool> {
         let cap = device.physical_device().memory_types().len();
         let hasher = BuildHasherDefault::<FnvHasher>::default();
 
@@ -76,14 +76,14 @@ unsafe impl MemoryPool for Arc<StdMemoryPool> {
             Entry::Vacant(entry) => {
                 match memory_type.is_host_visible() {
                     true => {
-                        let pool = StdHostVisibleMemoryTypePool::new(&self.device, memory_type);
+                        let pool = StdHostVisibleMemoryTypePool::new(self.device.clone(), memory_type);
                         entry.insert(Pool::HostVisible(pool.clone()));
                         let alloc = try!(StdHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::HostVisible(alloc);
                         Ok(StdMemoryPoolAlloc { inner: inner, pool: self.clone() })
                     },
                     false => {
-                        let pool = StdNonHostVisibleMemoryTypePool::new(&self.device, memory_type);
+                        let pool = StdNonHostVisibleMemoryTypePool::new(self.device.clone(), memory_type);
                         entry.insert(Pool::NonHostVisible(pool.clone()));
                         let alloc = try!(StdNonHostVisibleMemoryTypePool::alloc(&pool, size, alignment));
                         let inner = StdMemoryPoolAllocInner::NonHostVisible(alloc);

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -76,13 +76,13 @@ impl PipelineCache {
     ///
     /// let cache = if let Some(data) = data {
     ///     // This is unsafe because there is no way to be sure that the file contains valid data.
-    ///     unsafe { PipelineCache::with_data(&device, &data).unwrap() }
+    ///     unsafe { PipelineCache::with_data(device.clone(), &data).unwrap() }
     /// } else {
-    ///     PipelineCache::empty(&device).unwrap()
+    ///     PipelineCache::empty(device.clone()).unwrap()
     /// };
     /// ```
     #[inline]
-    pub unsafe fn with_data(device: &Arc<Device>, initial_data: &[u8])
+    pub unsafe fn with_data(device: Arc<Device>, initial_data: &[u8])
                             -> Result<Arc<PipelineCache>, OomError>
     {
         PipelineCache::new_impl(device, Some(initial_data))
@@ -97,15 +97,15 @@ impl PipelineCache {
     /// # use vulkano::device::Device;
     /// use vulkano::pipeline::cache::PipelineCache;
     /// # let device: Arc<Device> = return;
-    /// let cache = PipelineCache::empty(&device).unwrap();
+    /// let cache = PipelineCache::empty(device.clone()).unwrap();
     /// ```
     #[inline]
-    pub fn empty(device: &Arc<Device>) -> Result<Arc<PipelineCache>, OomError> {
+    pub fn empty(device: Arc<Device>) -> Result<Arc<PipelineCache>, OomError> {
         unsafe { PipelineCache::new_impl(device, None) }
     }
 
     // Actual implementation of the constructor.
-    unsafe fn new_impl(device: &Arc<Device>, initial_data: Option<&[u8]>)
+    unsafe fn new_impl(device: Arc<Device>, initial_data: Option<&[u8]>)
                        -> Result<Arc<PipelineCache>, OomError>
     {
         let vk = device.pointers();
@@ -232,7 +232,7 @@ mod tests {
     #[should_panic]
     fn merge_self_forbidden() {
         let (device, queue) = gfx_dev_and_queue!();
-        let pipeline = PipelineCache::empty(&device).unwrap();
+        let pipeline = PipelineCache::empty(device).unwrap();
         pipeline.merge(&[&pipeline]).unwrap();
     }
 }

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -56,7 +56,7 @@ struct Inner {
 
 impl ComputePipeline<()> {
     /// Builds a new `ComputePipeline`.
-    pub fn new<Css, Csl>(device: &Arc<Device>, shader: &ComputeShaderEntryPoint<Css, Csl>,
+    pub fn new<Css, Csl>(device: Arc<Device>, shader: &ComputeShaderEntryPoint<Css, Csl>,
                          specialization: &Css) 
                          -> Result<ComputePipeline<PipelineLayout<Csl>>, ComputePipelineCreationError>
         where Csl: PipelineLayoutDescNames + Clone,
@@ -64,7 +64,7 @@ impl ComputePipeline<()> {
     {
         let vk = device.pointers();
 
-        let pipeline_layout = shader.layout().clone().build(device).unwrap();     // TODO: error
+        let pipeline_layout = shader.layout().clone().build(device.clone()).unwrap();     // TODO: error
 
         PipelineLayoutSuperset::ensure_superset_of(pipeline_layout.desc(), shader.layout())?;
 

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -184,7 +184,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
     /// the other constructors for other possibilities.
     #[inline]
     pub fn new<'a, Vsp, Vi, Vo, Vl, Fs, Fi, Fo, Fl>
-              (device: &Arc<Device>,
+              (device: Arc<Device>,
                params: GraphicsPipelineParams<'a, Vdef, Vsp, Vi, Vo, Vl, (), (), (), EmptyPipelineDesc,
                                               (), (), (), EmptyPipelineDesc, (), (), (), EmptyPipelineDesc,
                                               Fs, Fi, Fo, Fl, Rp>)
@@ -203,7 +203,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
 
         let pl = params.vertex_shader.layout().clone()
                     .union(params.fragment_shader.layout().clone())
-                    .build(device).unwrap();      // TODO: error
+                    .build(device.clone()).unwrap();      // TODO: error
 
         GraphicsPipeline::new_inner::<_, _, _, _, (), (), (), EmptyPipelineDesc, (), (), (),
                                       EmptyPipelineDesc, (), (), (), EmptyPipelineDesc, _, _, _, _>
@@ -219,7 +219,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
     /// shader. See the other constructors for other possibilities.
     #[inline]
     pub fn with_geometry_shader<'a, Vsp, Vi, Vo, Vl, Gsp, Gi, Go, Gl, Fs, Fi, Fo, Fl>
-              (device: &Arc<Device>,
+              (device: Arc<Device>,
                params: GraphicsPipelineParams<'a, Vdef, Vsp, Vi, Vo, Vl, (), (), (), EmptyPipelineDesc,
                                               (), (), (), EmptyPipelineDesc, Gsp, Gi, Go, Gl, Fs, Fi,
                                               Fo, Fl, Rp>)
@@ -252,9 +252,9 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
         let pl = params.vertex_shader.layout().clone()
                     .union(params.fragment_shader.layout().clone())
                     .union(params.geometry_shader.as_ref().unwrap().layout().clone())    // FIXME: unwrap()
-                    .build(device).unwrap();      // TODO: error
+                    .build(device.clone()).unwrap();      // TODO: error
 
-        GraphicsPipeline::new_inner(device, params, pl)
+        GraphicsPipeline::new_inner(device.clone(), params, pl)
     }
 
     /// Builds a new graphics pipeline object with tessellation shaders.
@@ -268,7 +268,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
     #[inline]
     pub fn with_tessellation<'a, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes, Tei, Teo, Tel, Fs, Fi,
                             Fo, Fl>
-              (device: &Arc<Device>,
+              (device: Arc<Device>,
                params: GraphicsPipelineParams<'a, Vdef, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes,
                                               Tei, Teo, Tel, (), (), (), EmptyPipelineDesc, Fs, Fi,
                                               Fo, Fl, Rp>)
@@ -308,7 +308,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
                     .union(params.fragment_shader.layout().clone())
                     .union(params.tessellation.as_ref().unwrap().tessellation_control_shader.layout().clone())    // FIXME: unwrap()
                     .union(params.tessellation.as_ref().unwrap().tessellation_evaluation_shader.layout().clone())    // FIXME: unwrap()
-                    .build(device).unwrap();      // TODO: error
+                    .build(device.clone()).unwrap();      // TODO: error
 
         GraphicsPipeline::new_inner(device, params, pl)
     }
@@ -324,7 +324,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
     #[inline]
     pub fn with_tessellation_and_geometry<'a, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes, Tei, Teo, Tel, Gsp, Gi,
                              Go, Gl, Fs, Fi, Fo, Fl>
-              (device: &Arc<Device>,
+              (device: Arc<Device>,
                params: GraphicsPipelineParams<'a, Vdef, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes,
                                               Tei, Teo, Tel, Gsp, Gi, Go, Gl, Fs, Fi,
                                               Fo, Fl, Rp>)
@@ -377,7 +377,7 @@ impl<Vdef, Rp> GraphicsPipeline<Vdef, (), Rp>
                     .union(params.tessellation.as_ref().unwrap().tessellation_control_shader.layout().clone())    // FIXME: unwrap()
                     .union(params.tessellation.as_ref().unwrap().tessellation_evaluation_shader.layout().clone())    // FIXME: unwrap()
                     .union(params.geometry_shader.as_ref().unwrap().layout().clone())    // FIXME: unwrap()
-                    .build(device).unwrap();      // TODO: error
+                    .build(device.clone()).unwrap();      // TODO: error
 
         GraphicsPipeline::new_inner(device, params, pl)
     }
@@ -388,7 +388,7 @@ impl<Vdef, L, Rp> GraphicsPipeline<Vdef, L, Rp>
 {
     fn new_inner<'a, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes, Tei, Teo, Tel, Gsp, Gi, Go, Gl, Fs,
                  Fi, Fo, Fl>
-                (device: &Arc<Device>,
+                (device: Arc<Device>,
                  params: GraphicsPipelineParams<'a, Vdef, Vsp, Vi, Vo, Vl, Tcs, Tci, Tco, Tcl, Tes,
                                                 Tei, Teo, Tel, Gsp, Gi, Go, Gl, Fs, Fi, Fo, Fl, Rp>,
                  pipeline_layout: L)

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -241,11 +241,11 @@ pub struct OcclusionQueriesPool {
 
 impl OcclusionQueriesPool {
     /// See the docs of new().
-    pub fn raw(device: &Arc<Device>, num_slots: u32)
+    pub fn raw(device: Arc<Device>, num_slots: u32)
                -> Result<OcclusionQueriesPool, OomError>
     {
         Ok(OcclusionQueriesPool {
-            inner: match UnsafeQueryPool::new(device.clone(), QueryType::Occlusion, num_slots) {
+            inner: match UnsafeQueryPool::new(device, QueryType::Occlusion, num_slots) {
                 Ok(q) => q,
                 Err(QueryPoolCreationError::OomError(err)) => return Err(err),
                 Err(QueryPoolCreationError::PipelineStatisticsQueryFeatureNotEnabled) => {
@@ -262,7 +262,7 @@ impl OcclusionQueriesPool {
     /// - Panics if the device or host ran out of memory.
     ///
     #[inline]
-    pub fn new(device: &Arc<Device>, num_slots: u32)
+    pub fn new(device: Arc<Device>, num_slots: u32)
                -> Arc<OcclusionQueriesPool>
     {
        Arc::new(OcclusionQueriesPool::raw(device, num_slots).unwrap())
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn occlusion_create() {
         let (device, _) = gfx_dev_and_queue!();
-        let _ = OcclusionQueriesPool::new(&device, 256);
+        let _ = OcclusionQueriesPool::new(device, 256);
     }
 
     #[test]

--- a/vulkano/src/sampler.rs
+++ b/vulkano/src/sampler.rs
@@ -25,7 +25,7 @@
 //! use vulkano::sampler::Sampler;
 //!
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
-//! let _sampler = Sampler::simple_repeat_linear_no_mipmap(&device);
+//! let _sampler = Sampler::simple_repeat_linear_no_mipmap(device.clone());
 //! ```
 //!
 //! More detailed sampler creation:
@@ -34,7 +34,8 @@
 //! use vulkano::sampler;
 //!
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
-//! let _sampler = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+//! let _sampler = sampler::Sampler::new(device.clone(), sampler::Filter::Linear,
+//!                                      sampler::Filter::Linear,
 //!                                      sampler::MipmapMode::Nearest,
 //!                                      sampler::SamplerAddressMode::Repeat,
 //!                                      sampler::SamplerAddressMode::Repeat,
@@ -98,7 +99,7 @@ impl Sampler {
     /// - Panics if out of memory or the maximum number of samplers has exceeded.
     ///
     #[inline]
-    pub fn simple_repeat_linear(device: &Arc<Device>) -> Arc<Sampler> {
+    pub fn simple_repeat_linear(device: Arc<Device>) -> Arc<Sampler> {
         Sampler::new(device, Filter::Linear, Filter::Linear, MipmapMode::Linear,
                      SamplerAddressMode::Repeat, SamplerAddressMode::Repeat,
                      SamplerAddressMode::Repeat, 0.0, 1.0, 0.0, 1_000.0).unwrap()
@@ -114,7 +115,7 @@ impl Sampler {
     /// - Panics if out of memory or the maximum number of samplers has exceeded.
     ///
     #[inline]
-    pub fn simple_repeat_linear_no_mipmap(device: &Arc<Device>) -> Arc<Sampler> {
+    pub fn simple_repeat_linear_no_mipmap(device: Arc<Device>) -> Arc<Sampler> {
         Sampler::new(device, Filter::Linear, Filter::Linear, MipmapMode::Nearest,
                      SamplerAddressMode::Repeat, SamplerAddressMode::Repeat,
                      SamplerAddressMode::Repeat, 0.0, 1.0, 0.0, 1.0).unwrap()
@@ -146,7 +147,7 @@ impl Sampler {
     /// - Panics if `min_lod > max_lod`.
     ///
     #[inline(always)]
-    pub fn new(device: &Arc<Device>, mag_filter: Filter, min_filter: Filter,
+    pub fn new(device: Arc<Device>, mag_filter: Filter, min_filter: Filter,
                mipmap_mode: MipmapMode, address_u: SamplerAddressMode,
                address_v: SamplerAddressMode, address_w: SamplerAddressMode, mip_lod_bias: f32,
                max_anisotropy: f32, min_lod: f32, max_lod: f32)
@@ -173,7 +174,7 @@ impl Sampler {
     /// Same panic reasons as `new`.
     ///
     #[inline(always)]
-    pub fn compare(device: &Arc<Device>, mag_filter: Filter, min_filter: Filter,
+    pub fn compare(device: Arc<Device>, mag_filter: Filter, min_filter: Filter,
                    mipmap_mode: MipmapMode, address_u: SamplerAddressMode,
                    address_v: SamplerAddressMode, address_w: SamplerAddressMode, mip_lod_bias: f32,
                    max_anisotropy: f32, min_lod: f32, max_lod: f32, compare: Compare)
@@ -183,7 +184,7 @@ impl Sampler {
                           address_w, mip_lod_bias, max_anisotropy, min_lod, max_lod, Some(compare))
     }
 
-    fn new_impl(device: &Arc<Device>, mag_filter: Filter, min_filter: Filter,
+    fn new_impl(device: Arc<Device>, mag_filter: Filter, min_filter: Filter,
                 mipmap_mode: MipmapMode, address_u: SamplerAddressMode,
                 address_v: SamplerAddressMode, address_w: SamplerAddressMode, mip_lod_bias: f32,
                 max_anisotropy: f32, min_lod: f32, max_lod: f32, compare: Option<Compare>)
@@ -309,7 +310,7 @@ impl Sampler {
     ///
     /// - Panics if multiple `ClampToBorder` values are passed and the border color is different.
     ///
-    pub fn unnormalized(device: &Arc<Device>, filter: Filter,
+    pub fn unnormalized(device: Arc<Device>, filter: Filter,
                         address_u: UnnormalizedSamplerAddressMode,
                         address_v: UnnormalizedSamplerAddressMode)
                         -> Result<Arc<Sampler>, SamplerCreationError>
@@ -672,7 +673,7 @@ mod tests {
     fn create_regular() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let s = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let s = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -686,7 +687,7 @@ mod tests {
     fn create_compare() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let s = sampler::Sampler::compare(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let s = sampler::Sampler::compare(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                           sampler::MipmapMode::Nearest,
                                           sampler::SamplerAddressMode::Repeat,
                                           sampler::SamplerAddressMode::Repeat,
@@ -701,7 +702,7 @@ mod tests {
     fn create_unnormalized() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let s = sampler::Sampler::unnormalized(&device, sampler::Filter::Linear,
+        let s = sampler::Sampler::unnormalized(device, sampler::Filter::Linear,
                                                sampler::UnnormalizedSamplerAddressMode::ClampToEdge,
                                                sampler::UnnormalizedSamplerAddressMode::ClampToEdge)
                                                .unwrap();
@@ -713,13 +714,13 @@ mod tests {
     #[test]
     fn simple_repeat_linear() {
         let (device, queue) = gfx_dev_and_queue!();
-        let _ = sampler::Sampler::simple_repeat_linear(&device);
+        let _ = sampler::Sampler::simple_repeat_linear(device);
     }
 
     #[test]
     fn simple_repeat_linear_no_mipmap() {
         let (device, queue) = gfx_dev_and_queue!();
-        let _ = sampler::Sampler::simple_repeat_linear_no_mipmap(&device);
+        let _ = sampler::Sampler::simple_repeat_linear_no_mipmap(device);
     }
 
     #[test]
@@ -727,7 +728,7 @@ mod tests {
     fn min_lod_inferior() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let _ = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let _ = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -739,7 +740,7 @@ mod tests {
     fn max_anisotropy() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let _ = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let _ = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -754,7 +755,7 @@ mod tests {
         let b1 = sampler::BorderColor::IntTransparentBlack;
         let b2 = sampler::BorderColor::FloatOpaqueWhite;
 
-        let _ = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let _ = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::ClampToBorder(b1),
                                       sampler::SamplerAddressMode::ClampToBorder(b2),
@@ -765,7 +766,7 @@ mod tests {
     fn anisotropy_feature() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let r = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let r = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -781,7 +782,7 @@ mod tests {
     fn anisotropy_limit() {
         let (device, queue) = gfx_dev_and_queue!(sampler_anisotropy);
 
-        let r = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let r = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -798,7 +799,7 @@ mod tests {
     fn mip_lod_bias_limit() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let r = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let r = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::Repeat,
                                       sampler::SamplerAddressMode::Repeat,
@@ -815,7 +816,7 @@ mod tests {
     fn sampler_mirror_clamp_to_edge_extension() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let r = sampler::Sampler::new(&device, sampler::Filter::Linear, sampler::Filter::Linear,
+        let r = sampler::Sampler::new(device, sampler::Filter::Linear, sampler::Filter::Linear,
                                       sampler::MipmapMode::Nearest,
                                       sampler::SamplerAddressMode::MirrorClampToEdge,
                                       sampler::SamplerAddressMode::MirrorClampToEdge,

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -111,7 +111,7 @@ impl Swapchain {
     // TODO: remove `old_swapchain` parameter and add another function `with_old_swapchain`.
     // TODO: add `ColorSpace` parameter
     #[inline]
-    pub fn new<F, S>(device: &Arc<Device>, surface: &Arc<Surface>, num_images: u32, format: F,
+    pub fn new<F, S>(device: Arc<Device>, surface: &Arc<Surface>, num_images: u32, format: F,
                      dimensions: [u32; 2], layers: u32, usage: ImageUsage, sharing: S,
                      transform: SurfaceTransform, alpha: CompositeAlpha, mode: PresentMode,
                      clipped: bool, old_swapchain: Option<&Arc<Swapchain>>)
@@ -127,7 +127,7 @@ impl Swapchain {
     pub fn recreate_with_dimension(&self, dimensions: [u32; 2])
                                    -> Result<(Arc<Swapchain>, Vec<Arc<SwapchainImage>>), OomError>
     {
-        Swapchain::new_inner(&self.device, &self.surface, self.num_images, self.format,
+        Swapchain::new_inner(self.device.clone(), &self.surface, self.num_images, self.format,
                              self.color_space, dimensions, self.layers, self.usage,
                              self.sharing.clone(), self.transform, self.alpha, self.mode,
                              self.clipped, Some(self))
@@ -135,7 +135,7 @@ impl Swapchain {
 
     // TODO: images layouts should always be set to "PRESENT", since we have no way to switch the
     //       layout at present time
-    fn new_inner(device: &Arc<Device>, surface: &Arc<Surface>, num_images: u32, format: Format,
+    fn new_inner(device: Arc<Device>, surface: &Arc<Surface>, num_images: u32, format: Format,
                  color_space: ColorSpace, dimensions: [u32; 2], layers: u32, usage: ImageUsage,
                  sharing: SharingMode, transform: SurfaceTransform, alpha: CompositeAlpha,
                  mode: PresentMode, clipped: bool, old_swapchain: Option<&Swapchain>)
@@ -252,7 +252,7 @@ impl Swapchain {
         };
 
         let images = images.into_iter().enumerate().map(|(id, image)| unsafe {
-            let unsafe_image = UnsafeImage::from_raw(device, image, usage.to_usage_bits(), format,
+            let unsafe_image = UnsafeImage::from_raw(device.clone(), image, usage.to_usage_bits(), format,
                                                      ImageDimensions::Dim2d { width: dimensions[0], height: dimensions[1], array_layers: 1, cubemap_compatible: false }, 1, 1);
             SwapchainImage::from_raw(unsafe_image, format, &swapchain, id as u32).unwrap()     // TODO: propagate error
         }).collect::<Vec<_>>();


### PR DESCRIPTION
Big breaking change, but it eventually should be done.