### PR TITLE
Rename methods of RenderPassDesc

### DIFF
--- a/vulkano/src/command_buffer/cb/submit_sync.rs
+++ b/vulkano/src/command_buffer/cb/submit_sync.rs
@@ -250,7 +250,7 @@ impl<I> SubmitSyncBuilderLayer<I> {
         // TODO: slow
         for index in 0 .. FramebufferAbstract::attachments(framebuffer).len() {
             let key = Key::FramebufferAttachment(Box::new(framebuffer.clone()), index as u32);
-            let desc = framebuffer.attachment(index).expect("Wrong implementation of FramebufferAbstract trait");
+            let desc = framebuffer.attachment_desc(index).expect("Wrong implementation of FramebufferAbstract trait");
             let image = FramebufferAbstract::attachments(framebuffer)[index];
 
             let initial_layout = match self.behavior {

--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -29,7 +29,7 @@ pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usi
     where Rp: ?Sized + RenderPassDesc,
           I: ?Sized + ImageViewAccess
 {
-    let attachment_desc = render_pass.attachment(attachment_num)
+    let attachment_desc = render_pass.attachment_desc(attachment_num)
                                      .expect("Attachment num out of range");
 
     if image.format() != attachment_desc.format {
@@ -51,8 +51,8 @@ pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usi
     }
 
     for subpass_num in 0 .. render_pass.num_subpasses() {
-        let subpass = render_pass.subpass(subpass_num).expect("Subpass num out of range ; \
-                                                               wrong RenderPassDesc trait impl");
+        let subpass = render_pass.subpass_desc(subpass_num).expect("Subpass num out of range ; \
+                                                                    wrong RenderPassDesc trait impl");
 
         if subpass.color_attachments.iter().any(|&(n, _)| n == attachment_num) {
             debug_assert!(image.parent().has_color());  // Was normally checked by the render pass.

--- a/vulkano/src/framebuffer/desc.rs
+++ b/vulkano/src/framebuffer/desc.rs
@@ -49,37 +49,43 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
 {
     /// Returns the number of attachments of the render pass.
     fn num_attachments(&self) -> usize;
+
     /// Returns the description of an attachment.
     ///
     /// Returns `None` if `num` is superior to `num_attachments()`.
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription>;
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription>;
+
     /// Returns an iterator to the list of attachments.
     #[inline]
-    fn attachments(&self) -> RenderPassDescAttachments<Self> where Self: Sized {
+    fn attachment_descs(&self) -> RenderPassDescAttachments<Self> where Self: Sized {
         RenderPassDescAttachments { render_pass: self, num: 0 }
     }
 
     /// Returns the number of subpasses of the render pass.
     fn num_subpasses(&self) -> usize;
-    /// Returns the description of a suvpass.
+
+    /// Returns the description of a subpass.
     ///
     /// Returns `None` if `num` is superior to `num_subpasses()`.
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription>;
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription>;
+
     /// Returns an iterator to the list of subpasses.
     #[inline]
-    fn subpasses(&self) -> RenderPassDescSubpasses<Self> where Self: Sized {
+    fn subpass_descs(&self) -> RenderPassDescSubpasses<Self> where Self: Sized {
         RenderPassDescSubpasses { render_pass: self, num: 0 }
     }
 
     /// Returns the number of dependencies of the render pass.
     fn num_dependencies(&self) -> usize;
+
     /// Returns the description of a dependency.
     ///
     /// Returns `None` if `num` is superior to `num_dependencies()`.
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription>;
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription>;
+
     /// Returns an iterator to the list of dependencies.
     #[inline]
-    fn dependencies(&self) -> RenderPassDescDependencies<Self> where Self: Sized {
+    fn dependency_descs(&self) -> RenderPassDescDependencies<Self> where Self: Sized {
         RenderPassDescDependencies { render_pass: self, num: 0 }
     }
 
@@ -112,17 +118,17 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// Returns the number of color attachments of a subpass. Returns `None` if out of range.
     #[inline]
     fn num_color_attachments(&self, subpass: u32) -> Option<u32> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| p.color_attachments.len() as u32)
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| p.color_attachments.len() as u32)
     }
 
     /// Returns the number of samples of the attachments of a subpass. Returns `None` if out of
     /// range or if the subpass has no attachment. TODO: return an enum instead?
     #[inline]
     fn num_samples(&self, subpass: u32) -> Option<u32> {
-        (&self).subpasses().skip(subpass as usize).next().and_then(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().and_then(|p| {
             // TODO: chain input attachments as well?
             p.color_attachments.iter().cloned().chain(p.depth_stencil.clone().into_iter())
-                               .filter_map(|a| (&self).attachments().skip(a.0).next())
+                               .filter_map(|a| (&self).attachment_descs().skip(a.0).next())
                                .next().map(|a| a.samples)
         })
     }
@@ -131,13 +137,13 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// second element is `true` if there's a stencil attachment. Returns `None` if out of range.
     #[inline]
     fn has_depth_stencil_attachment(&self, subpass: u32) -> Option<(bool, bool)> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| {
             let atch_num = match p.depth_stencil {
                 Some((d, _)) => d,
                 None => return (false, false)
             };
 
-            match (&self).attachments().skip(atch_num).next().unwrap().format.ty() {
+            match (&self).attachment_descs().skip(atch_num).next().unwrap().format.ty() {
                 FormatTy::Depth => (true, false),
                 FormatTy::Stencil => (false, true),
                 FormatTy::DepthStencil => (true, true),
@@ -149,13 +155,13 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// Returns true if a subpass has a depth attachment or a depth-stencil attachment.
     #[inline]
     fn has_depth(&self, subpass: u32) -> Option<bool> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| {
             let atch_num = match p.depth_stencil {
                 Some((d, _)) => d,
                 None => return false
             };
 
-            match (&self).attachments().skip(atch_num).next().unwrap().format.ty() {
+            match (&self).attachment_descs().skip(atch_num).next().unwrap().format.ty() {
                 FormatTy::Depth => true,
                 FormatTy::Stencil => false,
                 FormatTy::DepthStencil => true,
@@ -168,7 +174,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// layout is not `DepthStencilReadOnlyOptimal`.
     #[inline]
     fn has_writable_depth(&self, subpass: u32) -> Option<bool> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| {
             let atch_num = match p.depth_stencil {
                 Some((d, l)) => {
                     if l == ImageLayout::DepthStencilReadOnlyOptimal { return false; }
@@ -177,7 +183,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
                 None => return false
             };
 
-            match (&self).attachments().skip(atch_num).next().unwrap().format.ty() {
+            match (&self).attachment_descs().skip(atch_num).next().unwrap().format.ty() {
                 FormatTy::Depth => true,
                 FormatTy::Stencil => false,
                 FormatTy::DepthStencil => true,
@@ -189,13 +195,13 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// Returns true if a subpass has a stencil attachment or a depth-stencil attachment.
     #[inline]
     fn has_stencil(&self, subpass: u32) -> Option<bool> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| {
             let atch_num = match p.depth_stencil {
                 Some((d, _)) => d,
                 None => return false
             };
 
-            match (&self).attachments().skip(atch_num).next().unwrap().format.ty() {
+            match (&self).attachment_descs().skip(atch_num).next().unwrap().format.ty() {
                 FormatTy::Depth => false,
                 FormatTy::Stencil => true,
                 FormatTy::DepthStencil => true,
@@ -208,7 +214,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
     /// layout is not `DepthStencilReadOnlyOptimal`.
     #[inline]
     fn has_writable_stencil(&self, subpass: u32) -> Option<bool> {
-        (&self).subpasses().skip(subpass as usize).next().map(|p| {
+        (&self).subpass_descs().skip(subpass as usize).next().map(|p| {
             let atch_num = match p.depth_stencil {
                 Some((d, l)) => {
                     if l == ImageLayout::DepthStencilReadOnlyOptimal { return false; }
@@ -217,7 +223,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> +
                 None => return false
             };
 
-            match (&self).attachments().skip(atch_num).next().unwrap().format.ty() {
+            match (&self).attachment_descs().skip(atch_num).next().unwrap().format.ty() {
                 FormatTy::Depth => false,
                 FormatTy::Stencil => true,
                 FormatTy::DepthStencil => true,
@@ -234,8 +240,8 @@ unsafe impl<T> RenderPassDesc for T where T: SafeDeref, T::Target: RenderPassDes
     }
 
     #[inline]
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription> {
-        (**self).attachment(num)
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+        (**self).attachment_desc(num)
     }
 
     #[inline]
@@ -244,8 +250,8 @@ unsafe impl<T> RenderPassDesc for T where T: SafeDeref, T::Target: RenderPassDes
     }
 
     #[inline]
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription> {
-        (**self).subpass(num)
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+        (**self).subpass_desc(num)
     }
 
     #[inline]
@@ -254,8 +260,8 @@ unsafe impl<T> RenderPassDesc for T where T: SafeDeref, T::Target: RenderPassDes
     }
 
     #[inline]
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
-        (**self).dependency(num)
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+        (**self).dependency_desc(num)
     }
 }
 
@@ -273,7 +279,7 @@ impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescAttachments<'a, R> where R: 
         if self.num < self.render_pass.num_attachments() {
             let n = self.num;
             self.num += 1;
-            Some(self.render_pass.attachment(n).expect("Wrong RenderPassDesc implementation"))
+            Some(self.render_pass.attachment_desc(n).expect("Wrong RenderPassDesc implementation"))
         } else {
             None
         }
@@ -294,7 +300,7 @@ impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescSubpasses<'a, R> where R: Re
         if self.num < self.render_pass.num_subpasses() {
             let n = self.num;
             self.num += 1;
-            Some(self.render_pass.subpass(n).expect("Wrong RenderPassDesc implementation"))
+            Some(self.render_pass.subpass_desc(n).expect("Wrong RenderPassDesc implementation"))
         } else {
             None
         }
@@ -315,7 +321,7 @@ impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescDependencies<'a, R> where R:
         if self.num < self.render_pass.num_dependencies() {
             let n = self.num;
             self.num += 1;
-            Some(self.render_pass.dependency(n).expect("Wrong RenderPassDesc implementation"))
+            Some(self.render_pass.dependency_desc(n).expect("Wrong RenderPassDesc implementation"))
         } else {
             None
         }

--- a/vulkano/src/framebuffer/empty.rs
+++ b/vulkano/src/framebuffer/empty.rs
@@ -49,7 +49,7 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
         None
     }
 
@@ -59,7 +59,7 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
         if num == 0 {
             Some(LayoutPassDescription {
                 color_attachments: vec![],
@@ -79,7 +79,7 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
         None
     }
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -268,8 +268,8 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A> where Rp: RenderPassDes
     }
 
     #[inline]
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription> {
-        self.render_pass.attachment(num)
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+        self.render_pass.attachment_desc(num)
     }
 
     #[inline]
@@ -278,8 +278,8 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A> where Rp: RenderPassDes
     }
     
     #[inline]
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription> {
-        self.render_pass.subpass(num)
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+        self.render_pass.subpass_desc(num)
     }
 
     #[inline]
@@ -288,8 +288,8 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A> where Rp: RenderPassDes
     }
 
     #[inline]
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
-        self.render_pass.dependency(num)
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+        self.render_pass.dependency_desc(num)
     }
 }
 

--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -129,7 +129,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn attachment(&self, id: usize) -> Option<LayoutAttachmentDescription> {
+                fn attachment_desc(&self, id: usize) -> Option<LayoutAttachmentDescription> {
                     attachment(self, id)
                 }
 
@@ -139,7 +139,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn subpass(&self, id: usize) -> Option<LayoutPassDescription> {
+                fn subpass_desc(&self, id: usize) -> Option<LayoutPassDescription> {
                     subpass(id)
                 }
 
@@ -149,7 +149,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn dependency(&self, id: usize) -> Option<LayoutPassDependencyDescription> {
+                fn dependency_desc(&self, id: usize) -> Option<LayoutPassDependencyDescription> {
                     dependency(id)
                 }
             }

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -73,12 +73,12 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
         // If the first use of an attachment in this render pass is as an input attachment, and
         // the attachment is not also used as a color or depth/stencil attachment in the same
         // subpass, then loadOp must not be VK_ATTACHMENT_LOAD_OP_CLEAR
-        debug_assert!(description.attachments().enumerate().all(|(atch_num, attachment)| {
+        debug_assert!(description.attachment_descs().enumerate().all(|(atch_num, attachment)| {
             if attachment.load != LoadOp::Clear {
                 return true;
             }
 
-            for p in description.subpasses() {
+            for p in description.subpass_descs() {
                 if p.color_attachments.iter().find(|&&(a, _)| a == atch_num).is_some() { return true; }
                 if let Some((a, _)) = p.depth_stencil { if a == atch_num { return true; } }
                 if p.input_attachments.iter().find(|&&(a, _)| a == atch_num).is_some() { return false; }
@@ -87,7 +87,7 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
             true
         }));
 
-        let attachments = description.attachments().map(|attachment| {
+        let attachments = description.attachment_descs().map(|attachment| {
             debug_assert!(attachment.samples.is_power_of_two());
 
             vk::AttachmentDescription {
@@ -109,7 +109,7 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
         // This block allocates, for each pass, in order, all color attachment references, then all
         // input attachment references, then all resolve attachment references, then the depth
         // stencil attachment reference.
-        let attachment_references = description.subpasses().flat_map(|pass| {
+        let attachment_references = description.subpass_descs().flat_map(|pass| {
             // Performing some validation with debug asserts.
             debug_assert!(pass.resolve_attachments.is_empty() ||
                           pass.resolve_attachments.len() == pass.color_attachments.len());
@@ -171,7 +171,7 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
         // Same as `attachment_references` but only for the preserve attachments.
         // This is separate because attachment references are u32s and not `vkAttachmentReference`
         // structs.
-        let preserve_attachments_references = description.subpasses().flat_map(|pass| {
+        let preserve_attachments_references = description.subpass_descs().flat_map(|pass| {
             pass.preserve_attachments.into_iter().map(|offset| offset as u32)
         }).collect::<SmallVec<[_; 16]>>();
 
@@ -184,7 +184,7 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
             let mut preserve_ref_index = 0usize;
             let mut out: SmallVec<[_; 16]> = SmallVec::new();
 
-            for pass in description.subpasses() {
+            for pass in description.subpass_descs() {
                 if pass.color_attachments.len() as u32 >
                    device.physical_device().limits().max_color_attachments()
                 {
@@ -235,7 +235,7 @@ impl<D> RenderPass<D> where D: RenderPassDesc {
             out
         };
 
-        let dependencies = description.dependencies().map(|dependency| {
+        let dependencies = description.dependency_descs().map(|dependency| {
             debug_assert!(dependency.source_subpass < passes.len());
             debug_assert!(dependency.destination_subpass < passes.len());
 
@@ -336,8 +336,8 @@ unsafe impl<D> RenderPassDesc for RenderPass<D> where D: RenderPassDesc {
     }
     
     #[inline]
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription> {
-        self.desc.attachment(num)
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+        self.desc.attachment_desc(num)
     }
 
     #[inline]
@@ -346,8 +346,8 @@ unsafe impl<D> RenderPassDesc for RenderPass<D> where D: RenderPassDesc {
     }
     
     #[inline]
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription> {
-        self.desc.subpass(num)
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+        self.desc.subpass_desc(num)
     }
 
     #[inline]
@@ -356,8 +356,8 @@ unsafe impl<D> RenderPassDesc for RenderPass<D> where D: RenderPassDesc {
     }
 
     #[inline]
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
-        self.desc.dependency(num)
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+        self.desc.dependency_desc(num)
     }
 }
 

--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -203,7 +203,7 @@ unsafe impl<A, B: ?Sized> RenderPassSubpassInterface<B> for A
     where A: RenderPassDesc, B: ShaderInterfaceDef
 {
     fn is_compatible_with(&self, subpass: u32, other: &B) -> bool {
-        let pass_descr = match RenderPassDesc::subpasses(self).skip(subpass as usize).next() {
+        let pass_descr = match RenderPassDesc::subpass_descs(self).skip(subpass as usize).next() {
             Some(s) => s,
             None => return false,
         };
@@ -215,7 +215,7 @@ unsafe impl<A, B: ?Sized> RenderPassSubpassInterface<B> for A
                     None => return false,
                 };
 
-                let attachment_desc = (&self).attachments().skip(attachment_id).next().unwrap();
+                let attachment_desc = (&self).attachment_descs().skip(attachment_id).next().unwrap();
 
                 // FIXME: compare formats depending on the number of components and data type
                 /*if attachment_desc.format != element.format {

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -1153,8 +1153,8 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn attachment(&self, num: usize) -> Option<LayoutAttachmentDescription> {
-        self.render_pass.attachment(num)
+    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+        self.render_pass.attachment_desc(num)
     }
 
     #[inline]
@@ -1163,8 +1163,8 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn subpass(&self, num: usize) -> Option<LayoutPassDescription> {
-        self.render_pass.subpass(num)
+    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+        self.render_pass.subpass_desc(num)
     }
 
     #[inline]
@@ -1173,8 +1173,8 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn dependency(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
-        self.render_pass.dependency(num)
+    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+        self.render_pass.dependency_desc(num)
     }
 }
 


### PR DESCRIPTION
Avoids ambiguities with the methods of `FramebufferAbstract`.