### PR TITLE
Future-proof a dependency on type inference

### DIFF
--- a/vulkano/src/command_buffer/commands_raw/pipeline_barrier.rs
+++ b/vulkano/src/command_buffer/commands_raw/pipeline_barrier.rs
@@ -102,8 +102,8 @@ impl<'a> CmdPipelineBarrier<'a> {
             self.dependency_flags = 0;
         }
 
-        self.src_stage_mask |= source.into();
-        self.dst_stage_mask |= dest.into();
+        self.src_stage_mask |= Into::<vk::PipelineStageFlags>::into(source);
+        self.dst_stage_mask |= Into::<vk::PipelineStageFlags>::into(dest);
     }
 
     /// Adds a memory barrier. This means that all the memory writes by the given source stages


### PR DESCRIPTION
In the Rust compiler, a pull request is being considered (see GitHub PR rust-lang/rust#41336) that will add support for `a |= &b` (instead of only `a |= b`) for numeric types like `u64`.

Unfortunately, this breaks the build of vulkano, because vulkano currently does the following in pipeline_barrier.rs:

```
self.src_stage_mask |= source.into();
self.dst_stage_mask |= dest.into();
```

Rust is currently able to infer that the result of `source.into()` must be a `vk::PipelineStageFlags`, because it gets bitor-ed to one. But if the PR on the compiler is accepted, this type inference will no longer be possible, because the return value of `source.into()` might then also be `&'a vk::PipelineStageFlags` for some lifetime `'a`.

This commit specifies the output type of the conversion explicitly, so that it doesn't require any type inference.