### PR TITLE
Add default generic parameter for AttachmentImage

### DIFF
--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -70,7 +70,7 @@ use sync::Sharing;
 ///
 // TODO: forbid reading transient images outside render passes?
 #[derive(Debug)]
-pub struct AttachmentImage<F, A = StdMemoryPoolAlloc> {
+pub struct AttachmentImage<F = Format, A = StdMemoryPoolAlloc> {
     // Inner implementation.
     image: UnsafeImage,
 


### PR DESCRIPTION
So that you can write `AttachmentImage` instead of `AttachmentImage<Format>` when you put the image in a struct.