### PR TITLE
Support enabling statically unknown extensions

### DIFF
--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -12,6 +12,7 @@ use std::ffi::{CString, CStr};
 use std::fmt;
 use std::ptr;
 use std::str;
+use std::collections::HashSet;
 
 use Error;
 use OomError;
@@ -24,7 +25,7 @@ use vk;
 use check_errors;
 
 macro_rules! extensions {
-    ($sname:ident, $($ext:ident => $s:expr,)*) => (
+    ($sname:ident, $rawname:ident, $($ext:ident => $s:expr,)*) => (
         /// List of extensions that are enabled or available.
         #[derive(Copy, Clone, PartialEq, Eq)]
         #[allow(missing_docs)]
@@ -48,13 +49,6 @@ macro_rules! extensions {
                     $($ext: false,)*
                     _unbuildable: Unbuildable(())
                 }
-            }
-
-            /// Builds a Vec containing the list of extensions.
-            pub fn build_extensions_list(&self) -> Vec<CString> {
-                let mut data = Vec::new();
-                $(if self.$ext { data.push(CString::new(&$s[..]).unwrap()); })*
-                data
             }
 
             /// Returns the intersection of this list and another list.
@@ -87,19 +81,107 @@ macro_rules! extensions {
                 write!(f, "]")
             }
         }
+
+        /// Set of extensions, not restricted to those vulkano knows about.
+        ///
+        /// This is useful when interacting with external code that has statically-unknown extension
+        /// requirements.
+        #[derive(Clone, Eq, PartialEq)]
+        pub struct $rawname(HashSet<CString>);
+
+        impl $rawname {
+            /// Constructs an extension set containing the supplied extensions.
+            pub fn new<'a, I>(extensions: I) -> Self
+                where I: IntoIterator<Item=CString>
+            {
+                $rawname(extensions.into_iter().collect())
+            }
+
+            /// Constructs an empty extension set.
+            pub fn none() -> Self { $rawname(HashSet::new()) }
+
+            /// Adds an extension to the set if it is not already present.
+            pub fn insert(&mut self, extension: CString) {
+                self.0.insert(extension);
+            }
+
+            /// Returns the intersection of this set and another.
+            pub fn intersection(&self, other: &Self) -> Self {
+                $rawname(self.0.intersection(&other.0).cloned().collect())
+            }
+
+            // TODO: impl Iterator
+            pub fn iter(&self) -> ::std::collections::hash_set::Iter<CString> { self.0.iter() }
+        }
+
+        impl fmt::Debug for $rawname {
+            #[allow(unused_assignments)]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl<'a> From<&'a $sname> for $rawname {
+            fn from(x: &'a $sname) -> Self {
+                let mut data = HashSet::new();
+                $(if x.$ext { data.insert(CString::new(&$s[..]).unwrap()); })*
+                $rawname(data)
+            }
+        }
+
+        impl<'a> From<&'a $rawname> for $sname {
+            fn from(x: &'a $rawname) -> Self {
+                let mut extensions = $sname::none();
+                $(
+                    if x.0.iter().any(|x| x.as_bytes() == &$s[..]) {
+                        extensions.$ext = true;
+                    }
+                )*
+                extensions
+            }
+        }
     );
 }
 
 macro_rules! instance_extensions {
-    ($sname:ident, $($ext:ident => $s:expr,)*) => (
+    ($sname:ident, $rawname:ident, $($ext:ident => $s:expr,)*) => (
         extensions! {
-            $sname,
+            $sname, $rawname,
             $( $ext => $s,)*
+        }
+
+        impl $rawname {
+            /// See the docs of supported_by_core().
+            pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
+                let entry_points = try!(loader::entry_points());
+
+                let properties: Vec<vk::ExtensionProperties> = unsafe {
+                    let mut num = 0;
+                    try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
+                        ptr::null(), &mut num, ptr::null_mut())));
+
+                    let mut properties = Vec::with_capacity(num as usize);
+                    try!(check_errors(entry_points.EnumerateInstanceExtensionProperties(
+                        ptr::null(), &mut num, properties.as_mut_ptr())));
+                    properties.set_len(num as usize);
+                    properties
+                };
+                Ok($rawname(properties.iter().map(|x| unsafe { CStr::from_ptr(x.extensionName.as_ptr()) }.to_owned()).collect()))
+            }
+
+            /// Returns a `RawExtensions` object with extensions supported by the core driver.
+            pub fn supported_by_core() -> Result<Self, LoadingError> {
+                match $rawname::supported_by_core_raw() {
+                    Ok(l) => Ok(l),
+                    Err(SupportedExtensionsError::LoadingError(e)) => Err(e),
+                    Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),
+                }
+            }
         }
 
         impl $sname {
             /// See the docs of supported_by_core().
-            pub fn supported_by_core_raw() -> Result<$sname, SupportedExtensionsError> {
+            pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
                 let entry_points = try!(loader::entry_points());
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
@@ -124,12 +206,11 @@ macro_rules! instance_extensions {
                         }
                     )*
                 }
-
                 Ok(extensions)
             }
 
-            /// Returns an `Extensions` object with extensions supported by the core driver.
-            pub fn supported_by_core() -> Result<$sname, LoadingError> {
+            /// Returns a `RawExtensions` object with extensions supported by the core driver.
+            pub fn supported_by_core() -> Result<Self, LoadingError> {
                 match $sname::supported_by_core_raw() {
                     Ok(l) => Ok(l),
                     Err(SupportedExtensionsError::LoadingError(e)) => Err(e),
@@ -141,15 +222,44 @@ macro_rules! instance_extensions {
 }
 
 macro_rules! device_extensions {
-    ($sname:ident, $($ext:ident => $s:expr,)*) => (
+    ($sname:ident, $rawname:ident, $($ext:ident => $s:expr,)*) => (
         extensions! {
-            $sname,
+            $sname, $rawname,
             $( $ext => $s,)*
+        }
+
+        impl $rawname {
+            /// See the docs of supported_by_device().
+            pub fn supported_by_device_raw(physical_device: &PhysicalDevice) -> Result<Self, SupportedExtensionsError> {
+                let vk = physical_device.instance().pointers();
+
+                let properties: Vec<vk::ExtensionProperties> = unsafe {
+                    let mut num = 0;
+                    try!(check_errors(vk.EnumerateDeviceExtensionProperties(
+                        physical_device.internal_object(), ptr::null(), &mut num, ptr::null_mut())));
+
+                    let mut properties = Vec::with_capacity(num as usize);
+                    try!(check_errors(vk.EnumerateDeviceExtensionProperties(
+                        physical_device.internal_object(), ptr::null(), &mut num, properties.as_mut_ptr())));
+                    properties.set_len(num as usize);
+                    properties
+                };
+                Ok($rawname(properties.iter().map(|x| unsafe { CStr::from_ptr(x.extensionName.as_ptr()) }.to_owned()).collect()))
+            }
+
+            /// Returns an `Extensions` object with extensions supported by the `PhysicalDevice`.
+            pub fn supported_by_device(physical_device: &PhysicalDevice) -> Self {
+                match $rawname::supported_by_device_raw(physical_device) {
+                    Ok(l) => l,
+                    Err(SupportedExtensionsError::LoadingError(e)) => unreachable!(),
+                    Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),
+                }
+            }
         }
 
         impl $sname {
             /// See the docs of supported_by_device().
-            pub fn supported_by_device_raw(physical_device: &PhysicalDevice) -> Result<$sname, SupportedExtensionsError> {
+            pub fn supported_by_device_raw(physical_device: &PhysicalDevice) -> Result<Self, SupportedExtensionsError> {
                 let vk = physical_device.instance().pointers();
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
@@ -179,7 +289,7 @@ macro_rules! device_extensions {
             }
 
             /// Returns an `Extensions` object with extensions supported by the `PhysicalDevice`.
-            pub fn supported_by_device(physical_device: &PhysicalDevice) -> $sname {
+            pub fn supported_by_device(physical_device: &PhysicalDevice) -> Self {
                 match $sname::supported_by_device_raw(physical_device) {
                     Ok(l) => l,
                     Err(SupportedExtensionsError::LoadingError(e)) => unreachable!(),
@@ -192,6 +302,7 @@ macro_rules! device_extensions {
 
 instance_extensions! {
     InstanceExtensions,
+    RawInstanceExtensions,
     khr_surface => b"VK_KHR_surface",
     khr_display => b"VK_KHR_display",
     khr_xlib_surface => b"VK_KHR_xlib_surface",
@@ -210,6 +321,7 @@ instance_extensions! {
 
 device_extensions! {
     DeviceExtensions,
+    RawDeviceExtensions,
     khr_swapchain => b"VK_KHR_swapchain",
     khr_display_swapchain => b"VK_KHR_display_swapchain",
     khr_sampler_mirror_clamp_to_edge => b"VK_KHR_sampler_mirror_clamp_to_edge",
@@ -287,15 +399,15 @@ pub struct Unbuildable(());
 
 #[cfg(test)]
 mod tests {
-    use instance::InstanceExtensions;
-    use instance::DeviceExtensions;
+    use instance::{InstanceExtensions, RawInstanceExtensions};
+    use instance::{DeviceExtensions, RawDeviceExtensions};
 
     #[test]
     fn empty_extensions() {
-        let i = InstanceExtensions::none().build_extensions_list();
-        assert!(i.is_empty());
+        let i: RawInstanceExtensions = (&InstanceExtensions::none()).into();
+        assert!(i.iter().next().is_none());
 
-        let d = DeviceExtensions::none().build_extensions_list();
-        assert!(d.is_empty());
+        let d: RawDeviceExtensions = (&DeviceExtensions::none()).into();
+        assert!(d.iter().next().is_none());
     }
 }

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -107,6 +107,8 @@
 pub use features::Features;
 pub use self::extensions::DeviceExtensions;
 pub use self::extensions::InstanceExtensions;
+pub use self::extensions::RawDeviceExtensions;
+pub use self::extensions::RawInstanceExtensions;
 pub use self::instance::Instance;
 pub use self::instance::InstanceCreationError;
 pub use self::instance::ApplicationInfo;


### PR DESCRIPTION
This allows vulkano to be used with libraries like OpenVR which require access to a vulkan instance with a set of extensions that can only be known at runtime.

OpenVR is dynamically loaded and is updated independently of applications, so it can easily come to require extensions which did not exist at the time an application was released. See [the OpenVR Vulkan docs](https://github.com/ValveSoftware/openvr/wiki/Vulkan#extensions) for details.

This is a (small) breaking change due to the removal of the `Copy` trait from the extension structs.