### PR TITLE
Allow specifying a filename for VulkanoShader src

### DIFF
--- a/vulkano-shader-derive/README.md
+++ b/vulkano-shader-derive/README.md
@@ -2,6 +2,8 @@
 
 This replaces `vulkano-shaders`.
 
+Either provide glsl source code directly as an attribute:
+
 ```rust
 #[macro_use]
 extern crate vulkano_shader_derive;
@@ -25,3 +27,21 @@ void main() {
 
 let fs = fs::Shader::load(&device).expect("failed to create shader module");
 ```
+
+Or by providing a path to a file containing the glsl code:
+
+```rust
+#[macro_use]
+extern crate vulkano_shader_derive;
+
+mod fs {
+    #[derive(VulkanoShader)]
+    #[ty = "fragment"]
+    #[path = "shader/fragment.glsl"]
+    struct Dummy;
+}
+
+let fs = fs::Shader::load(&device).expect("failed to create shader module");
+```
+
+Note that this file path is relative to the project's Cargo.toml, and not to the file the attribute is being used in.

--- a/vulkano-shader-derive/src/lib.rs
+++ b/vulkano-shader-derive/src/lib.rs
@@ -36,7 +36,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let source = iter.next().expect("No source attribute given ; put #[src = \"...\"] or #[path = \"...\"]");
 
         if iter.next().is_some() {
-            panic!("Multilpe src or path attributes given ; please provide only one");
+            panic!("Multiple src or path attributes given ; please provide only one");
         }
 
         match source {

--- a/vulkano-shader-derive/src/lib.rs
+++ b/vulkano-shader-derive/src/lib.rs
@@ -23,9 +23,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
             }
         }).next().expect("Can't find `src` attribute ; put #[src = \"...\"] for example.");
 
-        if Path::new(&src[..]).is_file() {
+        let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".into());
+        let path = Path::new(&root).join(&src[..]);
+
+        if path.is_file() {
             let mut buf = String::new();
-            File::open(src).and_then(|mut file| file.read_to_string(&mut buf)).expect("Unable to read source from given file");
+            File::open(path).and_then(|mut file| file.read_to_string(&mut buf)).expect("Unable to read source from given file");
             buf
         } else {
             src

--- a/vulkano-shader-derive/src/lib.rs
+++ b/vulkano-shader-derive/src/lib.rs
@@ -44,14 +44,16 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             SourceKind::Path(path) => {
                 let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".into());
-                let path = Path::new(&root).join(&path);
+                let full_path = Path::new(&root).join(&path);
 
-                if path.is_file() {
+                if full_path.is_file() {
                     let mut buf = String::new();
-                    File::open(path).and_then(|mut file| file.read_to_string(&mut buf)).expect("Unable to read source from given file");
+                    File::open(full_path)
+                        .and_then(|mut file| file.read_to_string(&mut buf))
+                        .expect(&format!("Error reading source from {:?}", path));
                     buf
                 } else {
-                    panic!("Given source file does not exist");
+                    panic!("File {:?} was not found ; note that the path must be relative to your Cargo.toml", path);
                 }
             }
         }

--- a/vulkano-shader-derive/src/lib.rs
+++ b/vulkano-shader-derive/src/lib.rs
@@ -32,9 +32,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    println!("Source: {}", src);
-
-
     let ty_str = syn_item.attrs.iter().filter_map(|attr| {
         match attr.value {
             syn::MetaItem::NameValue(ref i, syn::Lit::Str(ref val, _)) if i == "ty" => {

--- a/vulkano-shader-derive/src/lib.rs
+++ b/vulkano-shader-derive/src/lib.rs
@@ -3,20 +3,37 @@ extern crate proc_macro;
 extern crate syn;
 extern crate vulkano_shaders;
 
+use std::path::Path;
+use std::fs::File;
+use std::io::Read;
+
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(VulkanoShader, attributes(src, ty))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let syn_item = syn::parse_macro_input(&input.to_string()).unwrap();
 
-    let src = syn_item.attrs.iter().filter_map(|attr| {
-        match attr.value {
-            syn::MetaItem::NameValue(ref i, syn::Lit::Str(ref val, _)) if i == "src" => {
-                Some(val.clone())
-            },
-            _ => None
+    let src = {
+        let src = syn_item.attrs.iter().filter_map(|attr| {
+            match attr.value {
+                syn::MetaItem::NameValue(ref i, syn::Lit::Str(ref val, _)) if i == "src" => {
+                    Some(val.clone())
+                },
+                _ => None
+            }
+        }).next().expect("Can't find `src` attribute ; put #[src = \"...\"] for example.");
+
+        if Path::new(&src[..]).is_file() {
+            let mut buf = String::new();
+            File::open(src).and_then(|mut file| file.read_to_string(&mut buf)).expect("Unable to read source from given file");
+            buf
+        } else {
+            src
         }
-    }).next().expect("Can't find `src` attribute ; put #[src = \"...\"] for example.");
+    };
+
+    println!("Source: {}", src);
+
 
     let ty_str = syn_item.attrs.iter().filter_map(|attr| {
         match attr.value {


### PR DESCRIPTION
This is a small change that allows specifying

```rust
#[src = "filename"]
```

when deriving a shader, instead of placing the shader code directly in the attribute.

It checks if the string is a valid file, and if it is it attempts to read the source from the file. Otherwise, it treats the string as the shader source as before.