### PR TITLE
Fix actual type not being a reference

### DIFF
--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -181,7 +181,7 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: &winit::Window)
 
     unsafe {
         let wnd: cocoa_id = mem::transmute(win.get_nswindow());
-        
+
         let layer = CAMetalLayer::new();
 
         layer.set_edge_antialiasing_mask(0);
@@ -190,8 +190,8 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: &winit::Window)
 
         let view = wnd.contentView();
         view.setWantsLayer(YES);
-        view.setLayer(mem::transmute(layer.0));  // Bombs here with out of memory        
+        view.setLayer(mem::transmute(layer.0));  // Bombs here with out of memory
     }
-    
-    Surface::from_macos_moltenvk(instance, win.get_nsview() as *const ())
+
+    Surface::from_macos_moltenvk(&instance, win.get_nsview() as *const ())
 }


### PR DESCRIPTION
[`from_macos_moltenvk`](https://github.com/tomaka/vulkano/blob/da6faac1f32567b0b538533285cb683b4c00faff/vulkano/src/swapchain/surface.rs#L376) expects a `&Arc` instead of `Arc`.