### PR TITLE
Fix functions taking ref instead of value

### DIFF
--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -193,5 +193,5 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: &winit::Window)
         view.setLayer(mem::transmute(layer.0));  // Bombs here with out of memory
     }
 
-    Surface::from_macos_moltenvk(&instance, win.get_nsview() as *const ())
+    Surface::from_macos_moltenvk(instance, win.get_nsview() as *const ())
 }

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -336,7 +336,7 @@ impl Surface {
     /// - The caller must ensure that the `view` is correct and stays alive for the entire
     ///   lifetime of the surface.
     /// - The `UIView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
-    pub unsafe fn from_ios_moltenvk<T>(instance: &Arc<Instance>, view: *const T)
+    pub unsafe fn from_ios_moltenvk<T>(instance: Arc<Instance>, view: *const T)
                                        -> Result<Arc<Surface>, SurfaceCreationError>
     {
         let vk = instance.pointers();
@@ -373,7 +373,7 @@ impl Surface {
     /// - The caller must ensure that the `view` is correct and stays alive for the entire
     ///   lifetime of the surface.
     /// - The `NSView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
-    pub unsafe fn from_macos_moltenvk<T>(instance: &Arc<Instance>, view: *const T)
+    pub unsafe fn from_macos_moltenvk<T>(instance: Arc<Instance>, view: *const T)
                                          -> Result<Arc<Surface>, SurfaceCreationError>
     {
         let vk = instance.pointers();


### PR DESCRIPTION
As discussed [here](https://github.com/tomaka/vulkano/pull/502#issuecomment-306452974), it should have been the function param type that was changed as opposed to the callsite.