### PR TITLE
Set default final color attachment layout to PresentSrc

### DIFF
--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -276,7 +276,7 @@ macro_rules! ordered_passes_renderpass {
                             if initial_layout.is_none() {
                                 initial_layout = Some(ImageLayout::ColorAttachmentOptimal);
                             }
-                            final_layout = Some(ImageLayout::ColorAttachmentOptimal);
+                            final_layout = Some(ImageLayout::PresentSrc);
                         }
                     )*
 


### PR DESCRIPTION
I'm not certain whether this change is correct in a bigger-picture sense, so please review carefully, but it silences a validation error. For more advanced uses (e.g. deferred rendering) this may not be the correct setting, but those cases seem more likely to use custom render passes regardless, or perhaps more customization points are called for in this macro.