### PR TITLE
Enable validation layers in the examples

### DIFF
--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -22,6 +22,7 @@ use vulkano_win::VkSurfaceBuild;
 use vulkano::command_buffer::CommandBufferBuilder;
 use vulkano::sync::GpuFuture;
 use vulkano::image::ImageView;
+use vulkano::instance::debug::{self, DebugCallback};
 
 use std::sync::Arc;
 
@@ -29,8 +30,28 @@ fn main() {
     // The start of this example is exactly the same as `triangle`. You should read the
     // `triangle` example if you haven't done so yet.
 
-    let extensions = vulkano_win::required_extensions();
+    let extensions = vulkano::instance::InstanceExtensions {
+        ext_debug_report: true,
+        ..vulkano_win::required_extensions()
+    };
     let instance = vulkano::instance::Instance::new(None, &extensions, None).expect("failed to create instance");
+
+    let debug_callback = DebugCallback::new(&instance, debug::MessageTypes {
+        error: true,
+        warning: true,
+        performance_warning: true,
+        information: false,
+        debug: false,
+    }, move |msg| {
+        let level = if msg.ty.error {
+            "ERROR"
+        } else if msg.ty.warning || msg.ty.performance_warning {
+            "WARNING"
+        } else {
+            unreachable!();
+        };
+        println!("{}: {}: {}", level, msg.layer_prefix, msg.description);
+    }).expect("failed to create debug callback");
 
     let physical = vulkano::instance::PhysicalDevice::enumerate(&instance)
                             .next().expect("no device available");


### PR DESCRIPTION
This reveals two apparent bugs in vulkano:

> ERROR: DS: Cannot submit cmd buffer using image (0xc) [sub-resource: aspectMask 0x1 array layer 0, mip level 0], with layout VK_IMAGE_LAYOUT_UNDEFINED when first use is VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.

Appears to arise from the use of `copy_buffer_to_image` targeting an `ImmutableImage`. It's unclear to me how the layouts of `ImmutableImage`s are meant to be managed, but the error suggests that the barriers necessary to transition them aren't being properly configured or installed. I'd be happy to fix this if I can work that out.
> ERROR: DS: Images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR but is in VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL. For more information refer to Vulkan Spec Section '30.6. WSI Swapchain' which states 'Any given element of pImageIndices must be the index of a presentable image acquired from the swapchain specified by the corresponding element of the pSwapchains array, and the presented image subresource must be in the VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout at the time the operation is executed on a VkDevice' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/xhtml/vkspec.html#VkPresentInfoKHR)

Arises from presenting. #508 silences this error.