### PR TITLE
Panic when trying to create buffer from empty iterator

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -124,17 +124,18 @@ impl<T> CpuAccessibleBuffer<T> {
 impl<T> CpuAccessibleBuffer<[T]> {
     /// Builds a new buffer that contains an array `T`. The initial data comes from an iterator
     /// that produces that list of Ts.
-    /// # Panics
-    /// Panics if the initial data is empty.
     pub fn from_iter<'a, I, Q>(device: Arc<Device>, usage: BufferUsage, queue_families: Q, data: I)
                                -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: ExactSizeIterator<Item = T>,
               T: Content + 'static,
               Q: IntoIterator<Item = QueueFamily<'a>>
     {
-        assert_ne!(data.len(), 0, "Tried to create buffer from empty iterator.");
-
         unsafe {
+            // To avoid panicking on empty input data, create a 1-byte uninitialized buffer.
+            if data.len() == 0 {
+                return CpuAccessibleBuffer::uninitialized_array(device, 1, usage, queue_families);
+            };
+
             let uninitialized = try!(
                 CpuAccessibleBuffer::uninitialized_array(device, data.len(), usage, queue_families)
             );

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -132,7 +132,7 @@ impl<T> CpuAccessibleBuffer<[T]> {
               T: Content + 'static,
               Q: IntoIterator<Item = QueueFamily<'a>>
     {
-        assert_neq!(data.len(), 0, "Tried to create buffer from empty iterator.");
+        assert_ne!(data.len(), 0, "Tried to create buffer from empty iterator.");
 
         unsafe {
             let uninitialized = try!(

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -434,3 +434,17 @@ impl<'a, T: ?Sized + 'a> DerefMut for WriteLock<'a, T> {
         self.inner.deref_mut()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use buffer::{CpuAccessibleBuffer, BufferUsage};
+
+    #[test]
+    fn create_empty_buffer() {
+        let (device, queue) = gfx_dev_and_queue!();
+
+        const EMPTY: [i32; 0] = [];
+
+        CpuAccessibleBuffer::from_data(device, BufferUsage::all(), Some(queue.family()), EMPTY.iter());
+    }
+}

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -124,12 +124,16 @@ impl<T> CpuAccessibleBuffer<T> {
 impl<T> CpuAccessibleBuffer<[T]> {
     /// Builds a new buffer that contains an array `T`. The initial data comes from an iterator
     /// that produces that list of Ts.
+    /// # Panics
+    /// Panics if the initial data is empty.
     pub fn from_iter<'a, I, Q>(device: Arc<Device>, usage: BufferUsage, queue_families: Q, data: I)
                                -> Result<Arc<CpuAccessibleBuffer<[T]>>, OomError>
         where I: ExactSizeIterator<Item = T>,
               T: Content + 'static,
               Q: IntoIterator<Item = QueueFamily<'a>>
     {
+        assert_neq!(data.len(), 0, "Tried to create buffer from empty iterator.");
+
         unsafe {
             let uninitialized = try!(
                 CpuAccessibleBuffer::uninitialized_array(device, data.len(), usage, queue_families)

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -131,11 +131,6 @@ impl<T> CpuAccessibleBuffer<[T]> {
               Q: IntoIterator<Item = QueueFamily<'a>>
     {
         unsafe {
-            // To avoid panicking on empty input data, create a 1-byte uninitialized buffer.
-            if data.len() == 0 {
-                return CpuAccessibleBuffer::uninitialized_array(device, 1, usage, queue_families);
-            };
-
             let uninitialized = try!(
                 CpuAccessibleBuffer::uninitialized_array(device, data.len(), usage, queue_families)
             );

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -655,6 +655,13 @@ mod tests {
             .then_signal_fence_and_flush().unwrap();
     }
 
+    #[test]
+    fn create_buffer_zero_size_data() {
+        let (device, queue) = gfx_dev_and_queue!();
+
+        ImmutableBuffer::from_data((), BufferUsage::all(), Some(queue.family()), queue.clone());
+    }
+
     // TODO: write tons of tests that try to exploit loopholes
     // this isn't possible yet because checks aren't correctly implemented yet
 }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -70,6 +70,14 @@ impl UnsafeBuffer {
     {
         let vk = device.pointers();
 
+        // Ensure we're not trying to create an empty buffer.
+        let size = if size == 0 {
+            // To avoid panicking when allocating 0 bytes, use a 1-byte buffer.
+            1
+        } else {
+            size
+        };
+
         let usage_bits = usage_to_bits(usage);
 
         // Checking sparse features.
@@ -455,4 +463,13 @@ mod tests {
             }
         };
     }
+
+	#[test]
+	fn create_empty_buffer() {
+		let (device, _) = gfx_dev_and_queue!();
+
+		unsafe {
+            UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none())
+        };
+	}
 }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -464,12 +464,12 @@ mod tests {
         };
     }
 
-	#[test]
-	fn create_empty_buffer() {
-		let (device, _) = gfx_dev_and_queue!();
+    #[test]
+    fn create_empty_buffer() {
+        let (device, _) = gfx_dev_and_queue!();
 
-		unsafe {
+        unsafe {
             UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none())
         };
-	}
+    }
 }


### PR DESCRIPTION
This fixes #367, by adding an assertion with a proper error message in case the iterator is empty. Also added the potential `panic!` to the corresponding documentation section.