### PR TITLE
Fix warnings during build

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 vulkano = { path = "../vulkano" }
 vulkano-shader-derive = { path = "../vulkano-shader-derive" }
 vulkano-win = { path = "../vulkano-win" }
-cgmath = "0.12.0"
-image = "0.6.1"
+cgmath = "0.14.1"
+image = "0.14.0"
 winit = "0.6.4"
-time = "0.1.35"
+time = "0.1.37"

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[macro_use]
 extern crate vulkano;
 
 use vulkano::device::{Device, DeviceExtensions};

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+// For the purpose of this example all unused code is allowed.
+#![allow(dead_code)]
+
 extern crate cgmath;
 extern crate image;
 extern crate winit;

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+// For the purpose of this example all unused code is allowed.
+#![allow(dead_code)]
+
 extern crate examples;
 extern crate cgmath;
 extern crate winit;
@@ -21,7 +24,6 @@ extern crate vulkano_win;
 use vulkano_win::VkSurfaceBuild;
 use vulkano::command_buffer::CommandBufferBuilder;
 use vulkano::sync::GpuFuture;
-use vulkano::image::ImageView;
 
 use std::sync::Arc;
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -17,6 +17,8 @@
 // and that you want to learn Vulkan. This means that for example it won't go into details about
 // what a vertex or a shader is.
 
+// For the purpose of this example all unused code is allowed.
+#![allow(dead_code)]
 
 // The `vulkano` crate is the main crate that you must use to use Vulkan.
 #[macro_use]

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -10,6 +10,7 @@ extern crate metal_rs as metal;
 
 use std::error;
 use std::fmt;
+#[cfg(target_os = "windows")]
 use std::ptr;
 use std::sync::Arc;
 
@@ -29,6 +30,7 @@ use cocoa::appkit::{NSWindow, NSView};
 #[cfg(target_os = "macos")]
 use metal::*;
 
+#[cfg(target_os = "macos")]
 use std::mem;
 
 pub fn required_extensions() -> InstanceExtensions {

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -445,6 +445,6 @@ mod tests {
 
         const EMPTY: [i32; 0] = [];
 
-        CpuAccessibleBuffer::from_data(device, BufferUsage::all(), Some(queue.family()), EMPTY.iter());
+        let _ = CpuAccessibleBuffer::from_data(device, BufferUsage::all(), Some(queue.family()), EMPTY.iter());
     }
 }

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -659,7 +659,7 @@ mod tests {
     fn create_buffer_zero_size_data() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        ImmutableBuffer::from_data((), BufferUsage::all(), Some(queue.family()), queue.clone());
+        let _ = ImmutableBuffer::from_data((), BufferUsage::all(), Some(queue.family()), queue.clone());
     }
 
     // TODO: write tons of tests that try to exploit loopholes

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -469,7 +469,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         unsafe {
-            let _ = UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none())
+            let _ = UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none());
         };
     }
 }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -469,7 +469,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         unsafe {
-            UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none())
+            let _ = UnsafeBuffer::new(device, 0, BufferUsage::all(), Sharing::Exclusive::<Empty<_>>, SparseLevel::none())
         };
     }
 }

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -230,16 +230,7 @@ impl Swapchain {
                  -> Result<(Arc<Swapchain>, Vec<Arc<SwapchainImage>>), OomError>
     {
         // Checking that the requested parameters match the capabilities.
-        use swapchain::CapabilitiesError;
-        let capabilities = match surface.capabilities(device.physical_device()) {
-            Ok(caps) => caps,
-            Err(err) => match err {
-                CapabilitiesError::OomError(oom_err) => return Err(oom_err),
-                // TODO: this is what the old code did, while using the deprecated function.
-                // There should probably be a change to the API, to return a CapabilitiesError instead.
-                CapabilitiesError::SurfaceLost => panic!("Surface lost while creating swapchain")
-            }
-        };
+        let capabilities = try!(surface.get_capabilities(&device.physical_device()));
         // TODO: return errors instead
         assert!(num_images >= capabilities.min_image_count);
         if let Some(c) = capabilities.max_image_count { assert!(num_images <= c) };


### PR DESCRIPTION
Back with another pull request :smile:

I noticed there are a lot of warnings issued by the compiler during normal / Travis CI build. It clutters up the log and *probably* makes it harder to notice *real* errors. 

Short summary of the changes:
- removed unused imports / allowed dead code in the examples.
- added various #[cfg(...)] attributes to the imports in the `vulkano-win` crate (e.g. some `use` statements were used on Windows, but not on Linux).
- updated the versions of the libraries used by the `example`s. The `color-rs` crate was causing a lot of warnings in the log.
- replace the use of a deprecated function in the `swapchain` module.

<hr/>

Note, however, that there is one little problem: the old code used the [`surface.get_capabilities()`](https://docs.rs/vulkano/0.4.1/vulkano/swapchain/struct.Surface.html#method.get_capabilities) function, which panicked on errors. 

I've replaced it with the new [`surface.capabilities()`](https://docs.rs/vulkano/0.4.1/vulkano/swapchain/struct.Surface.html#method.capabilities) function, which returns a `CapabilitiesError`. 

However, because I didn't want to change the return type of `Swapchain::new_inner` I pass through `OomError`s and panic on `CapabilitiesError`, as before.

A decision should be made: should we change the public API of `Swapchain::new_inner`, and if so, which error type to use?