### PR TITLE
Add Travis CI caching for Cargo crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ rust:
     - nightly
     - stable
 
-cache: cargo
+cache:
+  cargo
 
 install:
   - export CXX="g++-4.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rust:
     - nightly
     - stable
 
+cache: cargo
+
 install:
   - export CXX="g++-4.8"
 


### PR DESCRIPTION
A lot of time is spent during CI for downloading and compiling dependencies. Since most of these dependencies don't change every build, the source and the binaries can be cached and reused. 

Travis CI has built-in support for this caching of Cargo crates, it just has to be enabled. Now, vulkano's build times (~ 10-15 mins) aren't *extremely* long, but if this improves them, it would be great.

The instructions for doing this are [here](https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache). This pull request adds the required line to the `.travis.yml` file. It will take a few rebuilds until the caching becomes noticeable.

Note: this does not cache the glslang build. Additional work is required to cache it.