### PR TITLE
replace occurences of `CpuAccessBuffer` with `CpuAccessibleBuffer`

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -366,7 +366,7 @@ pub struct CpuAccessibleBufferFinished {
     write: bool,
 }
 
-/// Object that can be used to read or write the content of a `CpuAccessBuffer`.
+/// Object that can be used to read or write the content of a `CpuAccessibleBuffer`.
 ///
 /// Note that this object holds a rwlock read guard on the chunk. If another thread tries to access
 /// this buffer's content or tries to submit a GPU command that uses this buffer, it will block.
@@ -397,7 +397,7 @@ impl<'a, T: ?Sized + 'a> Deref for ReadLock<'a, T> {
     }
 }
 
-/// Object that can be used to read or write the content of a `CpuAccessBuffer`.
+/// Object that can be used to read or write the content of a `CpuAccessibleBuffer`.
 ///
 /// Note that this object holds a rwlock write guard on the chunk. If another thread tries to access
 /// this buffer's content or tries to submit a GPU command that uses this buffer, it will block.

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -20,11 +20,11 @@
 //! provides high-level wrappers around that type that are specialized depending on the way you
 //! are going to use it:
 //!
-//! - `CpuAccessBuffer` designates a buffer located in RAM and whose content can be directly
+//! - `CpuAccessibleBuffer` designates a buffer located in RAM and whose content can be directly
 //!   written by your application.
 //! - `DeviceLocalBuffer` designates a buffer located in video memory and whose content can't be
 //!   written by your application. Accessing this buffer from the GPU is usually faster than the
-//!   `CpuAccessBuffer`.
+//!   `CpuAccessibleBuffer`.
 //! - `ImmutableBuffer` designates a buffer in video memory and whose content can only be
 //!   written once. Compared to `DeviceLocalBuffer`, this buffer requires less processing on the
 //!   CPU because we don't need to keep track of the reads and writes.


### PR DESCRIPTION
replace occurences of `CpuAccessBuffer` with `CpuAccessibleBuffer` in docs.