### PR TITLE
Change Image::inner() to allow a base mipmap and array layer

### DIFF
--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -62,7 +62,7 @@ pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usi
             .any(|&(n, _)| n == attachment_num)
         {
             debug_assert!(image.parent().has_color()); // Was normally checked by the render pass.
-            if !image.parent().inner().usage_color_attachment() {
+            if !image.parent().inner().image.usage_color_attachment() {
                 return Err(IncompatibleRenderPassAttachmentError::MissingColorAttachmentUsage);
             }
         }
@@ -71,7 +71,7 @@ pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usi
             if ds == attachment_num {
                 // Was normally checked by the render pass.
                 debug_assert!(image.parent().has_depth() || image.parent().has_stencil());
-                if !image.parent().inner().usage_depth_stencil_attachment() {
+                if !image.parent().inner().image.usage_depth_stencil_attachment() {
                     return Err(IncompatibleRenderPassAttachmentError::MissingDepthStencilAttachmentUsage);
                 }
             }
@@ -82,7 +82,7 @@ pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usi
             .iter()
             .any(|&(n, _)| n == attachment_num)
         {
-            if !image.parent().inner().usage_input_attachment() {
+            if !image.parent().inner().image.usage_input_attachment() {
                 return Err(IncompatibleRenderPassAttachmentError::MissingInputAttachmentUsage);
             }
         }

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -21,6 +21,7 @@ use format::FormatDesc;
 use format::FormatTy;
 use image::Dimensions;
 use image::ImageDimensions;
+use image::ImageInner;
 use image::ImageLayout;
 use image::ImageUsage;
 use image::ViewType;
@@ -264,8 +265,14 @@ unsafe impl<F, A> ImageAccess for AttachmentImage<F, A>
     where F: 'static + Send + Sync
 {
     #[inline]
-    fn inner(&self) -> &UnsafeImage {
-        &self.image
+    fn inner(&self) -> ImageInner {
+        ImageInner {
+            image: &self.image,
+            first_layer: 0,
+            num_layers: self.image.dimensions().array_layers() as usize,
+            first_mipmap_level: 0,
+            num_mipmap_levels: 1,
+        }
     }
 
     #[inline]

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -16,6 +16,7 @@ use format::Format;
 use format::FormatDesc;
 use image::Dimensions;
 use image::ImageDimensions;
+use image::ImageInner;
 use image::ImageLayout;
 use image::ImageUsage;
 use image::MipmapsCount;
@@ -162,8 +163,14 @@ unsafe impl<F, A> ImageAccess for ImmutableImage<F, A>
           A: MemoryPool
 {
     #[inline]
-    fn inner(&self) -> &UnsafeImage {
-        &self.image
+    fn inner(&self) -> ImageInner {
+        ImageInner {
+            image: &self.image,
+            first_layer: 0,
+            num_layers: self.image.dimensions().array_layers() as usize,
+            first_mipmap_level: 0,
+            num_mipmap_levels: self.image.mipmap_levels() as usize,
+        }
     }
 
     #[inline]

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -53,6 +53,7 @@ pub use self::storage::StorageImage;
 pub use self::swapchain::SwapchainImage;
 pub use self::sys::ImageCreationError;
 pub use self::traits::ImageAccess;
+pub use self::traits::ImageInner;
 pub use self::traits::ImageViewAccess;
 pub use self::usage::ImageUsage;
 

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -21,6 +21,7 @@ use format::FormatDesc;
 use format::FormatTy;
 use image::Dimensions;
 use image::ImageDimensions;
+use image::ImageInner;
 use image::ImageLayout;
 use image::ImageUsage;
 use image::sys::ImageCreationError;
@@ -172,8 +173,14 @@ unsafe impl<F, A> ImageAccess for StorageImage<F, A>
           A: MemoryPool
 {
     #[inline]
-    fn inner(&self) -> &UnsafeImage {
-        &self.image
+    fn inner(&self) -> ImageInner {
+        ImageInner {
+            image: &self.image,
+            first_layer: 0,
+            num_layers: self.dimensions.array_layers() as usize,
+            first_mipmap_level: 0,
+            num_mipmap_levels: 1,
+        }
     }
 
     #[inline]

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -15,6 +15,7 @@ use format::Format;
 use format::FormatDesc;
 use image::Dimensions;
 use image::ImageDimensions;
+use image::ImageInner;
 use image::ImageLayout;
 use image::ViewType;
 use image::sys::UnsafeImage;
@@ -55,7 +56,7 @@ impl SwapchainImage {
     pub unsafe fn from_raw(swapchain: Arc<Swapchain>, id: usize)
                            -> Result<Arc<SwapchainImage>, OomError> {
         let image = swapchain.raw_image(id).unwrap();
-        let view = UnsafeImageView::raw(&image, ViewType::Dim2d, 0 .. 1, 0 .. 1)?;
+        let view = UnsafeImageView::raw(&image.image, ViewType::Dim2d, 0 .. 1, 0 .. 1)?;
 
         Ok(Arc::new(SwapchainImage {
                         swapchain: swapchain.clone(),
@@ -69,7 +70,7 @@ impl SwapchainImage {
     /// A `SwapchainImage` is always two-dimensional.
     #[inline]
     pub fn dimensions(&self) -> [u32; 2] {
-        let dims = self.my_image().dimensions();
+        let dims = self.my_image().image.dimensions();
         [dims.width(), dims.height()]
     }
 
@@ -80,14 +81,14 @@ impl SwapchainImage {
     }
 
     #[inline]
-    fn my_image(&self) -> &UnsafeImage {
+    fn my_image(&self) -> ImageInner {
         self.swapchain.raw_image(self.image_offset).unwrap()
     }
 }
 
 unsafe impl ImageAccess for SwapchainImage {
     #[inline]
-    fn inner(&self) -> &UnsafeImage {
+    fn inner(&self) -> ImageInner {
         self.my_image()
     }
 
@@ -103,7 +104,7 @@ unsafe impl ImageAccess for SwapchainImage {
 
     #[inline]
     fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
-        self.my_image().key()
+        self.my_image().image.key()
     }
 
     #[inline]


### PR DESCRIPTION
Similar to `Buffer::inner()`.

The point of this change is to allow implementations of `Image` to operate over pools.
For example you allocate an image of 3 layers, and you use a different layer at each frame.
