### PR TITLE
Expose unsafe acquire_next_image variant

### DIFF
--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -207,12 +207,14 @@ pub use self::capabilities::SurfaceTransform;
 pub use self::surface::CapabilitiesError;
 pub use self::surface::Surface;
 pub use self::surface::SurfaceCreationError;
+pub use self::swapchain::AcquiredImage;
 pub use self::swapchain::AcquireError;
 pub use self::swapchain::PresentFuture;
 pub use self::swapchain::Swapchain;
 pub use self::swapchain::SwapchainAcquireFuture;
 pub use self::swapchain::SwapchainCreationError;
 pub use self::swapchain::acquire_next_image;
+pub use self::swapchain::acquire_next_image_raw;
 pub use self::swapchain::present;
 
 mod capabilities;


### PR DESCRIPTION
This enables convenient swapchain use in applications using UnsafeCommandBuffers to render.