### PR TITLE
Fix resources being unlocked when they shouldn't be

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -637,9 +637,14 @@ unsafe impl<P> CommandBuffer for AutoCommandBuffer<P> {
     }
 
     #[inline]
-    fn prepare_submit(&self, future: &GpuFuture, queue: &Queue)
-                      -> Result<(), CommandBufferExecError> {
-        self.inner.prepare_submit(future, queue)
+    fn lock_submit(&self, future: &GpuFuture, queue: &Queue)
+                   -> Result<(), CommandBufferExecError> {
+        self.inner.lock_submit(future, queue)
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        self.inner.unlock()
     }
 
     #[inline]

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -283,8 +283,10 @@ unsafe impl<F, Cb> GpuFuture for CommandBufferExecFuture<F, Cb>
 
     #[inline]
     unsafe fn signal_finished(&self) {
-        self.finished.store(true, Ordering::SeqCst);
-        self.command_buffer.unlock();
+        if self.finished.swap(true, Ordering::SeqCst) == false {
+            self.command_buffer.unlock();
+        }
+
         self.previous.signal_finished();
     }
 

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -60,6 +60,7 @@ pub unsafe trait CommandBuffer: DeviceOwned {
     /// the given queue, and if so locks it.
     ///
     /// If you call this function, then you should call `unlock` afterwards.
+    // TODO: require `&mut self` instead, but this has some consequences on other parts of the lib
     fn lock_submit(&self, future: &GpuFuture, queue: &Queue)
                    -> Result<(), CommandBufferExecError>;
 
@@ -68,6 +69,7 @@ pub unsafe trait CommandBuffer: DeviceOwned {
     /// # Safety
     ///
     /// Must not be called if you haven't called `lock_submit` before.
+    // TODO: require `&mut self` instead, but this has some consequences on other parts of the lib
     unsafe fn unlock(&self);
 
     /// Executes this command buffer on a queue.

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -90,6 +90,9 @@ pub unsafe trait GpuFuture: DeviceOwned {
     ///
     /// This must only be done if you called `build_submission()`, submitted the returned
     /// submission, and determined that it was finished.
+    ///
+    /// The implementation must be aware that this function can be called multiple times on the
+    /// same future.
     unsafe fn signal_finished(&self);
 
     /// Returns the queue that triggers the event. Returns `None` if unknown or irrelevant.


### PR DESCRIPTION
Before this PR a command buffer would unlock its resources in its destructor, which is obviously a mistake because if the command buffer wasn't submitted then the resources weren't locked.

This change also makes it possible to submit the same command buffer multiple times, although you have to do that manually for now.
