### PR TITLE
Pass -j 1 flag to cargo test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - cmake-data
 
 script:
-    - cargo test --all
+    - cargo test --all -j 1
 
 after_success:
     - |


### PR DESCRIPTION
Prevents some travis failures caused by the lack of RAM on their machines