### PR TITLE
Remove DescriptorBufferContentDesc

### DIFF
--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -286,7 +286,6 @@ fn descriptor_infos(doc: &parse::Spirv, pointed_ty: u32, force_combined_image_sa
                 let desc = format!("DescriptorDescTy::Buffer(DescriptorBufferDesc {{
                     dynamic: Some(false),
                     storage: {},
-                    content: DescriptorBufferContentDesc::F32,      // FIXME: wrong
                 }})", if is_ssbo { "true" } else { "false "});
 
                 Some((desc, true, 1))

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -89,8 +89,6 @@ pub fn reflect<R>(name: &str, mut spirv: R) -> Result<String, Error>
         #[allow(unused_imports)]
         use vulkano::descriptor::descriptor::DescriptorBufferDesc;
         #[allow(unused_imports)]
-        use vulkano::descriptor::descriptor::DescriptorBufferContentDesc;
-        #[allow(unused_imports)]
         use vulkano::descriptor::descriptor::DescriptorImageDesc;
         #[allow(unused_imports)]
         use vulkano::descriptor::descriptor::DescriptorImageDescDimensions;

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -376,19 +376,6 @@ impl DescriptorImageDescDimensions {
 pub struct DescriptorBufferDesc {
     pub dynamic: Option<bool>,
     pub storage: bool,
-    pub content: DescriptorBufferContentDesc,
-}
-
-// TODO: documentation
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DescriptorBufferContentDesc {
-    F32,
-    F64,
-    Struct {},
-    Array {
-        len: Box<DescriptorBufferContentDesc>,
-        num_array: usize,
-    },
 }
 
 /// Describes what kind of resource may later be bound to a descriptor.

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -989,7 +989,6 @@ impl DescriptorWrite {
 
 #[cfg(test)]
 mod tests {
-    use descriptor::descriptor::DescriptorBufferContentDesc;
     use descriptor::descriptor::DescriptorBufferDesc;
     use descriptor::descriptor::DescriptorDesc;
     use descriptor::descriptor::DescriptorDescTy;
@@ -1040,7 +1039,6 @@ mod tests {
             ty: DescriptorDescTy::Buffer(DescriptorBufferDesc {
                                              dynamic: Some(false),
                                              storage: false,
-                                             content: DescriptorBufferContentDesc::F32,
                                          }),
             array_count: 1,
             stages: ShaderStages::all_graphics(),
@@ -1071,7 +1069,6 @@ mod tests {
             ty: DescriptorDescTy::Buffer(DescriptorBufferDesc {
                                              dynamic: Some(false),
                                              storage: false,
-                                             content: DescriptorBufferContentDesc::F32,
                                          }),
             array_count: 1,
             stages: ShaderStages::all_graphics(),

--- a/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
+++ b/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
@@ -145,7 +145,6 @@ impl Drop for UnsafeDescriptorSetLayout {
 
 #[cfg(test)]
 mod tests {
-    use descriptor::descriptor::DescriptorBufferContentDesc;
     use descriptor::descriptor::DescriptorBufferDesc;
     use descriptor::descriptor::DescriptorDesc;
     use descriptor::descriptor::DescriptorDescTy;
@@ -168,7 +167,6 @@ mod tests {
             ty: DescriptorDescTy::Buffer(DescriptorBufferDesc {
                                              dynamic: Some(false),
                                              storage: false,
-                                             content: DescriptorBufferContentDesc::F32,
                                          }),
             array_count: 1,
             stages: ShaderStages::all_graphics(),


### PR DESCRIPTION
See #608 

Initially the idea was to make sure that the layout of content of the buffer expected by the shader was the same as the actual layout.
This is now abandoned because too cumbersome and too "weird".