### PR TITLE
Add DeviceMemory::dedicated_alloc

### DIFF
--- a/vk-sys/Cargo.toml
+++ b/vk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vk-sys"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 repository = "https://github.com/tomaka/vulkano"
 description = "Bindings for the Vulkan graphics API"

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -180,6 +180,8 @@ pub const STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR: u32 = 1
 pub const STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN: u32 = 1000062000;
 pub const STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR: u32 = 1000080000;
 pub const STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR: u32 = 1000085000;
+pub const STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR: u32 = 1000127000;
+pub const STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR: u32 = 1000127001;
 
 pub type SystemAllocationScope = u32;
 pub const SYSTEM_ALLOCATION_SCOPE_COMMAND: u32 = 0;
@@ -2584,6 +2586,21 @@ pub struct DescriptorUpdateTemplateCreateInfoKHR {
     pub set: u32,
 }
 
+#[repr(C)]
+pub struct MemoryDedicatedRequirementsKHR {
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub prefersDedicatedAllocation: Bool32,
+    pub requiresDedicatedAllocation: Bool32,
+}
+
+#[repr(C)]
+pub struct MemoryDedicatedAllocateInfoKHR {
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub image: Image,
+    pub buffer: Buffer,
+}
 
 macro_rules! ptrs {
     ($struct_name:ident, { $($name:ident => ($($param_n:ident: $param_ty:ty),*) -> $ret:ty,)+ }) => (

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -15,4 +15,4 @@ fnv = "1.0.5"
 shared_library = "0.1.5"
 smallvec = "0.3.1"
 lazy_static = "0.2.2"
-vk-sys = { version = "0.2.5", path = "../vk-sys" }
+vk-sys = { version = "0.2.6", path = "../vk-sys" }

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -356,6 +356,7 @@ device_extensions! {
     khr_display_swapchain => b"VK_KHR_display_swapchain",
     khr_sampler_mirror_clamp_to_edge => b"VK_KHR_sampler_mirror_clamp_to_edge",
     khr_maintenance1 => b"VK_KHR_maintenance1",
+    khr_dedicated_allocation => b"VK_KHR_dedicated_allocation",
 }
 
 /// Error that can happen when loading the list of layers.

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -67,10 +67,10 @@ impl DeviceMemory {
         DeviceMemory::dedicated_alloc(device, memory_type, size, DedicatedAlloc::None)
     }
                 
-    /// Same as `alloc`, but allows specifying a resource that we will be bound to the memory.
+    /// Same as `alloc`, but allows specifying a resource that will be bound to the memory.
     ///
-    /// If `resource` is different from `None`, then the returned memory must not be bound to a
-    /// different buffer or image.
+    /// If a buffer or an image is specified in `resource`, then the returned memory must not be
+    /// bound to a different buffer or image.
     ///
     /// If the `VK_KHR_dedicated_allocation` extension is enabled on the device, then it will be
     /// used by this method. Otherwise the `resource` parameter will be ignored.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -89,6 +89,8 @@ use std::mem;
 use std::os::raw::c_void;
 use std::slice;
 
+use buffer::sys::UnsafeBuffer;
+use image::sys::UnsafeImage;
 use vk;
 
 pub use self::device_memory::CpuAccess;
@@ -125,6 +127,13 @@ impl From<vk::MemoryRequirements> for MemoryRequirements {
             memory_type_bits: reqs.memoryTypeBits,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum DedicatedAlloc<'a> {
+    None,
+    Buffer(&'a UnsafeBuffer),
+    Image(&'a UnsafeImage),
 }
 
 /// Trait for types of data that can be mapped.


### PR DESCRIPTION
cc #640 

This adds supports for the `VK_KHR_dedicated_allocation` extension in `DeviceMemory`.
If the extension is enabled, then it will be used. Otherwise the dedicated resource is ignored.

Note however that right now these methods are not actually used by the rest of vulkano.
