### PR TITLE
Add support for khr_get_memory_requirements2

### DIFF
--- a/vk-sys/Cargo.toml
+++ b/vk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vk-sys"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 repository = "https://github.com/tomaka/vulkano"
 description = "Bindings for the Vulkan graphics API"

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -182,6 +182,11 @@ pub const STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR: u32 = 1
 pub const STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR: u32 = 1000085000;
 pub const STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR: u32 = 1000127000;
 pub const STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR: u32 = 1000127001;
+pub const STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR: u32 = 1000146000;
+pub const STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR: u32 = 1000146001;
+pub const STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2_KHR: u32 = 1000146002;
+pub const STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR: u32 = 1000146003;
+pub const STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2_KHR: u32 = 1000146004;
 
 pub type SystemAllocationScope = u32;
 pub const SYSTEM_ALLOCATION_SCOPE_COMMAND: u32 = 0;
@@ -2602,6 +2607,27 @@ pub struct MemoryDedicatedAllocateInfoKHR {
     pub buffer: Buffer,
 }
 
+#[repr(C)]
+pub struct BufferMemoryRequirementsInfo2KHR {
+    pub sType: StructureType,
+    pub pNext: *mut c_void,
+    pub buffer: Buffer,
+}
+
+#[repr(C)]
+pub struct ImageMemoryRequirementsInfo2KHR {
+    pub sType: StructureType,
+    pub pNext: *mut c_void,
+    pub image: Image,
+}
+
+#[repr(C)]
+pub struct MemoryRequirements2KHR {
+    pub sType: StructureType,
+    pub pNext: *mut c_void,
+    pub memoryRequirements: MemoryRequirements,
+}
+
 macro_rules! ptrs {
     ($struct_name:ident, { $($name:ident => ($($param_n:ident: $param_ty:ty),*) -> $ret:ty,)+ }) => (
         pub struct $struct_name {
@@ -2848,4 +2874,6 @@ ptrs!(DevicePointers, {
     DestroyDescriptorUpdateTemplateKHR => (device: Device, descriptorUpdateTemplate: DescriptorUpdateTemplateKHR, pAllocator: *const AllocationCallbacks) -> (),
     UpdateDescriptorSetWithTemplateKHR => (device: Device, descriptorSet: DescriptorSet, descriptorUpdateTemplate: DescriptorUpdateTemplateKHR, pData: *const c_void) -> (),
     CmdPushDescriptorSetWithTemplateKHR => (commandBuffer: CommandBuffer, descriptorUpdateTemplate: DescriptorUpdateTemplateKHR, layout: PipelineLayout, set: u32, pData: *const c_void) -> (),
+    GetImageMemoryRequirements2KHR => (device: Device, pInfo: *const ImageMemoryRequirementsInfo2KHR, pMemoryRequirements: *mut MemoryRequirements2KHR) -> (),
+    GetBufferMemoryRequirements2KHR => (device: Device, pInfo: *const BufferMemoryRequirementsInfo2KHR, pMemoryRequirements: *mut MemoryRequirements2KHR) -> (),
 });

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -15,4 +15,4 @@ fnv = "1.0.5"
 shared_library = "0.1.5"
 smallvec = "0.3.1"
 lazy_static = "0.2.2"
-vk-sys = { version = "0.2.6", path = "../vk-sys" }
+vk-sys = { version = "0.2.7", path = "../vk-sys" }

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -356,6 +356,7 @@ device_extensions! {
     khr_display_swapchain => b"VK_KHR_display_swapchain",
     khr_sampler_mirror_clamp_to_edge => b"VK_KHR_sampler_mirror_clamp_to_edge",
     khr_maintenance1 => b"VK_KHR_maintenance1",
+    khr_get_memory_requirements2 => b"VK_KHR_get_memory_requirements2",
     khr_dedicated_allocation => b"VK_KHR_dedicated_allocation",
 }
 

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -102,7 +102,8 @@ pub use self::pool::MemoryPool;
 mod device_memory;
 pub mod pool;
 
-/// Represents requirements expressed by the Vulkan implementation.
+/// Represents requirements expressed by the Vulkan implementation when it comes to binding memory
+/// to a resource.
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryRequirements {
     /// Number of bytes of memory required.
@@ -115,6 +116,14 @@ pub struct MemoryRequirements {
     /// Indicates which memory types can be used. Each bit that is set to 1 means that the memory
     /// type whose index is the same as the position of the bit can be used.
     pub memory_type_bits: u32,
+
+    /// True if the implementation prefers to use dedicated allocations (in other words, allocate
+    /// a whole block of memory dedicated to this resource alone). If the implementation doesn't
+    /// support dedicated allocations, this will be false.
+    ///
+    /// > **Note**: As its name says, using a dedicated allocation is an optimization and not a
+    /// > requirement.
+    pub prefer_dedicated: bool,
 }
 
 #[doc(hidden)]
@@ -125,6 +134,7 @@ impl From<vk::MemoryRequirements> for MemoryRequirements {
             size: reqs.size as usize,
             alignment: reqs.alignment as usize,
             memory_type_bits: reqs.memoryTypeBits,
+            prefer_dedicated: false,
         }
     }
 }


### PR DESCRIPTION
cc #640 

The purpose of this PR is that it adds a `prefer_dedicated` field to `MemoryRequirements`.

Since dedicated allocations require whole blocks, we can't use a memory pool when using them. Therefore it's a good idea to not try to use dedicated allocations when the implementation doesn't care about them.