### PR TITLE
Fix the sync command buffer being too strict

### DIFF
--- a/vulkano/src/command_buffer/synced.rs
+++ b/vulkano/src/command_buffer/synced.rs
@@ -2520,7 +2520,7 @@ unsafe impl<P> CommandBuffer for SyncCommandBuffer<P> {
 
         if let Some(value) = self.resources.get(&CbKey::BufferRef(buffer)) {
             if !value.exclusive && exclusive {
-                return Err(AccessCheckError::Denied(AccessError::ExclusiveDenied));
+                return Err(AccessCheckError::Unknown);
             }
 
             return Ok(Some((value.final_stages, value.final_access)));
@@ -2544,7 +2544,7 @@ unsafe impl<P> CommandBuffer for SyncCommandBuffer<P> {
             }
 
             if !value.exclusive && exclusive {
-                return Err(AccessCheckError::Denied(AccessError::ExclusiveDenied));
+                return Err(AccessCheckError::Unknown);
             }
 
             return Ok(Some((value.final_stages, value.final_access)));


### PR DESCRIPTION
When we have non-exclusive access to a resource but an exclusive access is requested, we should not immediately fail with an error. Instead we should ask the future we got the access from.