### PR TITLE
CpuBufferPool improvement

### DIFF
--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -42,6 +42,10 @@ use sync::Sharing;
 
 use OomError;
 
+// TODO: Add `CpuBufferPoolSubbuffer::read` to read the content of a subbuffer.
+//       But that's hard to do because we must prevent `increase_gpu_lock` from working while a
+//       a buffer is locked.
+
 /// Buffer from which "sub-buffers" can be individually allocated.
 ///
 /// This buffer is especially suitable when you want to upload or download some data at each frame.

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -14,6 +14,7 @@ use smallvec::SmallVec;
 use std::iter;
 use std::marker::PhantomData;
 use std::mem;
+use std::ptr;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
@@ -41,25 +42,25 @@ use sync::Sharing;
 
 use OomError;
 
-/// Buffer from which "sub-buffers" of fixed size can be individually allocated.
+/// Buffer from which "sub-buffers" can be individually allocated.
 ///
 /// This buffer is especially suitable when you want to upload or download some data at each frame.
 ///
 /// # BufferUsage
 ///
-/// A `CpuBufferPool` is a bit similar to a `Vec`. You start by creating an empty pool, then you
+/// A `CpuBufferPool` is similar to a ring buffer. You start by creating an empty pool, then you
 /// grab elements from the pool and use them, and if the pool is full it will automatically grow
 /// in size.
 ///
-/// But contrary to a `Vec`, elements automatically free themselves when they are dropped (ie.
-/// usually when they are no longer in use by the GPU).
+/// Contrary to a `Vec`, elements automatically free themselves when they are dropped (ie. usually
+/// when they are no longer in use by the GPU).
 ///
 /// # Arc-like
 ///
 /// The `CpuBufferPool` struct internally contains an `Arc`. You can clone the `CpuBufferPool` for
 /// a cheap cost, and all the clones will share the same underlying buffer.
 ///
-pub struct CpuBufferPool<T: ?Sized, A = Arc<StdMemoryPool>>
+pub struct CpuBufferPool<T, A = Arc<StdMemoryPool>>
     where A: MemoryPool
 {
     // The device of the pool.
@@ -68,11 +69,8 @@ pub struct CpuBufferPool<T: ?Sized, A = Arc<StdMemoryPool>>
     // The memory pool to use for allocations.
     pool: A,
 
-    // Current buffer from which subbuffers are grabbed.
+    // Current buffer from which elements are grabbed.
     current_buffer: Mutex<Option<Arc<ActualBuffer<A>>>>,
-
-    // Size in bytes of one subbuffer.
-    one_size: usize,
 
     // Buffer usage.
     usage: BufferUsage,
@@ -94,40 +92,46 @@ struct ActualBuffer<A>
     // The memory held by the buffer.
     memory: A::Alloc,
 
-    // Access pattern of the subbuffers.
-    subbuffers: Vec<ActualBufferSubbuffer>,
+    // List of the chunks that are reserved.
+    chunks_in_use: Mutex<Vec<ActualBufferChunk>>,
 
-    // The subbuffer that should be available next.
-    next_subbuffer: AtomicUsize,
+    // The index of the chunk that should be available next for the ring buffer.
+    next_index: AtomicUsize,
 
-    // Number of subbuffers in the buffer.
+    // Number of elements in the buffer.
     capacity: usize,
 }
 
 // Access pattern of one subbuffer.
 #[derive(Debug)]
-struct ActualBufferSubbuffer {
+struct ActualBufferChunk {
+    // First element number within the actual buffer.
+    index: usize,
+
+    // Number of occupied elements within the actual buffer.
+    len: usize,
+
     // Number of `CpuBufferPoolSubbuffer` objects that point to this subbuffer.
-    num_cpu_accesses: AtomicUsize,
+    num_cpu_accesses: usize,
 
     // Number of `CpuBufferPoolSubbuffer` objects that point to this subbuffer and that have been
     // GPU-locked.
-    num_gpu_accesses: AtomicUsize,
+    num_gpu_accesses: usize,
 }
 
 /// A subbuffer allocated from a `CpuBufferPool`.
 ///
 /// When this object is destroyed, the subbuffer is automatically reclaimed by the pool.
-pub struct CpuBufferPoolSubbuffer<T: ?Sized, A>
+pub struct CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     buffer: Arc<ActualBuffer<A>>,
 
-    // Index of the subbuffer within `buffer`.
-    subbuffer_index: usize,
+    // Index of the subbuffer within `buffer`. In number of elements.
+    index: usize,
 
-    // Size in bytes of the subbuffer.
-    size: usize,
+    // Size of the subbuffer in number of elements.
+    len: usize,
 
     // Necessary to make it compile.
     marker: PhantomData<Box<T>>,
@@ -153,23 +157,16 @@ impl<T> CpuBufferPool<T> {
     }
 }
 
-impl<T> CpuBufferPool<[T]> {
-    #[inline]
-    #[deprecated(note = "Useless ; use new and allocate chunks instead")]
-    pub fn array<'a, I>(device: Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
-                        -> CpuBufferPool<[T]>
-        where I: IntoIterator<Item = QueueFamily<'a>>
-    {
-        unsafe { CpuBufferPool::raw(device, mem::size_of::<T>() * len, usage, queue_families) }
-    }
-}
-
-impl<T: ?Sized> CpuBufferPool<T> {
+impl<T> CpuBufferPool<T> {
     #[deprecated(note = "Useless ; use new instead")]
     pub unsafe fn raw<'a, I>(device: Arc<Device>, one_size: usize, usage: BufferUsage,
                              queue_families: I) -> CpuBufferPool<T>
         where I: IntoIterator<Item = QueueFamily<'a>>
     {
+        // This assertion was added after the method was deprecated. The logic of the
+        // implementation doesn't hold if `one_size` is not equal to the size of `T`.
+        assert_eq!(one_size, mem::size_of::<T>());
+
         let queue_families = queue_families
             .into_iter()
             .map(|f| f.id())
@@ -181,7 +178,6 @@ impl<T: ?Sized> CpuBufferPool<T> {
             device: device,
             pool: pool,
             current_buffer: Mutex::new(None),
-            one_size: one_size,
             usage: usage.clone(),
             queue_families: queue_families,
             marker: PhantomData,
@@ -226,6 +222,22 @@ impl<T, A> CpuBufferPool<T, A>
     /// > **Note**: You can think of it like a `Vec`. If you insert an element and the `Vec` is not
     /// > large enough, a new chunk of memory is automatically allocated.
     pub fn next(&self, data: T) -> CpuBufferPoolSubbuffer<T, A> {
+        self.chunk(iter::once(data))
+    }
+
+    /// Grants access to a new subbuffer and puts `data` in it.
+    ///
+    /// If no subbuffer is available (because they are still in use by the GPU), a new buffer will
+    /// automatically be allocated.
+    ///
+    /// > **Note**: You can think of it like a `Vec`. If you insert elements and the `Vec` is not
+    /// > large enough, a new chunk of memory is automatically allocated.
+    pub fn chunk<I>(&self, data: I) -> CpuBufferPoolSubbuffer<T, A>
+        where I: IntoIterator<Item = T>,
+              I::IntoIter: ExactSizeIterator
+    {
+        let data = data.into_iter();
+
         let mut mutex = self.current_buffer.lock().unwrap();
 
         let data = match self.try_next_impl(&mut mutex, data) {
@@ -233,12 +245,13 @@ impl<T, A> CpuBufferPool<T, A>
             Err(d) => d,
         };
 
-        let next_capacity = match *mutex {
+        // TODO: choose the capacity better?
+        let next_capacity = data.len() * match *mutex {
             Some(ref b) => b.capacity * 2,
             None => 3,
         };
 
-        self.reset_buf(&mut mutex, next_capacity).unwrap(); /* FIXME: error */
+        self.reset_buf(&mut mutex, next_capacity).unwrap(); /* FIXME: propagate error */
 
         match self.try_next_impl(&mut mutex, data) {
             Ok(n) => n,
@@ -255,10 +268,10 @@ impl<T, A> CpuBufferPool<T, A>
     #[inline]
     pub fn try_next(&self, data: T) -> Option<CpuBufferPoolSubbuffer<T, A>> {
         let mut mutex = self.current_buffer.lock().unwrap();
-        self.try_next_impl(&mut mutex, data).ok()
+        self.try_next_impl(&mut mutex, iter::once(data)).ok()
     }
 
-    // Creates a new buffer and sets it as current.
+    // Creates a new buffer and sets it as current. The capacity is in number of elements.
     //
     // `cur_buf_mutex` must be an active lock of `self.current_buffer`.
     fn reset_buf(&self, cur_buf_mutex: &mut MutexGuard<Option<Arc<ActualBuffer<A>>>>,
@@ -272,13 +285,13 @@ impl<T, A> CpuBufferPool<T, A>
                     Sharing::Exclusive
                 };
 
-                let total_size = match self.one_size.checked_mul(capacity) {
+                let size_bytes = match mem::size_of::<T>().checked_mul(capacity) {
                     Some(s) => s,
                     None => return Err(DeviceMemoryAllocError::OomError(OomError::OutOfDeviceMemory)),
                 };
 
                 match UnsafeBuffer::new(self.device.clone(),
-                                          total_size,
+                                          size_bytes,
                                           self.usage,
                                           sharing,
                                           SparseLevel::none()) {
@@ -310,18 +323,9 @@ impl<T, A> CpuBufferPool<T, A>
                 Some(Arc::new(ActualBuffer {
                                   inner: buffer,
                                   memory: mem,
-                                  subbuffers: {
-                                      let mut v = Vec::with_capacity(capacity);
-                                      for _ in 0 .. capacity {
-                                          v.push(ActualBufferSubbuffer {
-                                                     num_cpu_accesses: AtomicUsize::new(0),
-                                                     num_gpu_accesses: AtomicUsize::new(0),
-                                                 });
-                                      }
-                                      v
-                                  },
+                                  chunks_in_use: Mutex::new(vec![]),
+                                  next_index: AtomicUsize::new(0),
                                   capacity: capacity,
-                                  next_subbuffer: AtomicUsize::new(0),
                               }));
 
             Ok(())
@@ -333,62 +337,86 @@ impl<T, A> CpuBufferPool<T, A>
     // `cur_buf_mutex` must be an active lock of `self.current_buffer`.
     //
     // Returns `data` wrapped inside an `Err` if there is no slot available in the current buffer.
-    fn try_next_impl(&self, cur_buf_mutex: &mut MutexGuard<Option<Arc<ActualBuffer<A>>>>, data: T)
-                     -> Result<CpuBufferPoolSubbuffer<T, A>, T> {
+    fn try_next_impl<I>(&self, cur_buf_mutex: &mut MutexGuard<Option<Arc<ActualBuffer<A>>>>,
+                        data: I) -> Result<CpuBufferPoolSubbuffer<T, A>, I>
+        where I: ExactSizeIterator<Item = T>
+    {
         // Grab the current buffer. Return `Err` if the pool wasn't "initialized" yet.
         let current_buffer = match cur_buf_mutex.clone() {
             Some(b) => b,
             None => return Err(data),
         };
 
-        // Grab the next subbuffer to use.
-        let next_subbuffer = {
-            // Since the only place that touches `next_subbuffer` is this code, and since we own a
-            // mutex lock to the buffer, it means that `next_subbuffer` can't be accessed
-            // concurrently.
-            let val = current_buffer
-                .next_subbuffer
-                .fetch_add(1, Ordering::Relaxed);
-            // TODO: handle overflows?
-            // TODO: rewrite this in a proper way by holding an intermediary struct in the mutex instead of the Arc directly
-            val % current_buffer.capacity
+        let mut chunks_in_use = current_buffer.chunks_in_use.lock().unwrap();
+        let data_len = data.len();
+
+        // Find a suitable offset, or return if none available.
+        let index = {
+            let next_index = {
+                // Since the only place that touches `next_index` is this code, and since we
+                // own a mutex lock to the buffer, it means that `next_index` can't be accessed
+                // concurrently.
+                // TODO: ^ eventually should be put inside the mutex
+                current_buffer
+                    .next_index
+                    .load(Ordering::SeqCst)
+            };
+
+            // Find out whether any chunk in use overlaps this range.
+            if next_index + data_len <= current_buffer.capacity &&
+                !chunks_in_use.iter().any(|c| (c.index >= next_index && c.index < next_index + data_len) ||
+                    (c.index <= next_index && c.index + c.len >= next_index))
+            {
+                next_index
+            } else {
+                // Impossible to allocate at `next_index`. Let's try 0 instead.
+                if data_len <= current_buffer.capacity &&
+                    !chunks_in_use.iter().any(|c| c.index < data_len)
+                {
+                    0
+                } else {
+                    // Buffer is full. Return.
+                    return Err(data);
+                }
+            }
         };
-
-        // Check if subbuffer is already taken. If so, the pool is full.
-        if current_buffer.subbuffers[next_subbuffer]
-            .num_cpu_accesses
-            .compare_and_swap(0, 1, Ordering::SeqCst) != 0
-        {
-            return Err(data);
-        }
-
-        // Reset num_gpu_accesses.
-        current_buffer.subbuffers[next_subbuffer]
-            .num_gpu_accesses
-            .store(0, Ordering::SeqCst);
 
         // Write `data` in the memory.
         unsafe {
-            let range = (next_subbuffer * self.one_size) .. ((next_subbuffer + 1) * self.one_size);
+            let range = (index * mem::size_of::<T>()) .. ((index + data_len) * mem::size_of::<T>());
             let mut mapping = current_buffer
                 .memory
                 .mapped_memory()
                 .unwrap()
-                .read_write(range);
-            *mapping = data;
+                .read_write::<[T]>(range);
+
+            // TODO: assert that the data has been entirely written, in case the iterator's content didn't match the len
+            for (o, i) in mapping.iter_mut().zip(data) {
+                ptr::write(o, i);
+            }
         }
 
+        // Mark the chunk as in use.
+        current_buffer.next_index.store(index + data_len, Ordering::SeqCst);
+        chunks_in_use.push(ActualBufferChunk {
+            index,
+            len: data_len,
+            num_cpu_accesses: 1,
+            num_gpu_accesses: 0,
+        });
+
         Ok(CpuBufferPoolSubbuffer {
-               buffer: current_buffer,
-               subbuffer_index: next_subbuffer,
-               size: self.one_size,
+               // TODO: remove .clone() once non-lexical borrows land
+               buffer: current_buffer.clone(),
+               index: index,
+               len: data_len,
                marker: PhantomData,
            })
     }
 }
 
 // Can't automatically derive `Clone`, otherwise the compiler adds a `T: Clone` requirement.
-impl<T: ?Sized, A> Clone for CpuBufferPool<T, A>
+impl<T, A> Clone for CpuBufferPool<T, A>
     where A: MemoryPool + Clone
 {
     fn clone(&self) -> Self {
@@ -398,7 +426,6 @@ impl<T: ?Sized, A> Clone for CpuBufferPool<T, A>
             device: self.device.clone(),
             pool: self.pool.clone(),
             current_buffer: Mutex::new(buf.clone()),
-            one_size: self.one_size,
             usage: self.usage.clone(),
             queue_families: self.queue_families.clone(),
             marker: PhantomData,
@@ -406,7 +433,7 @@ impl<T: ?Sized, A> Clone for CpuBufferPool<T, A>
     }
 }
 
-unsafe impl<T: ?Sized, A> DeviceOwned for CpuBufferPool<T, A>
+unsafe impl<T, A> DeviceOwned for CpuBufferPool<T, A>
     where A: MemoryPool
 {
     #[inline]
@@ -415,87 +442,103 @@ unsafe impl<T: ?Sized, A> DeviceOwned for CpuBufferPool<T, A>
     }
 }
 
-impl<T: ?Sized, A> Clone for CpuBufferPoolSubbuffer<T, A>
+impl<T, A> Clone for CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     fn clone(&self) -> CpuBufferPoolSubbuffer<T, A> {
-        let old_val = self.buffer.subbuffers[self.subbuffer_index]
-            .num_cpu_accesses
-            .fetch_add(1, Ordering::SeqCst);
-        debug_assert!(old_val >= 1);
+        let mut chunks_in_use_lock = self.buffer.chunks_in_use.lock().unwrap();
+        let chunk = chunks_in_use_lock.iter_mut().find(|c| c.index == self.index).unwrap();
+
+        debug_assert!(chunk.num_cpu_accesses >= 1);
+        chunk.num_cpu_accesses = chunk.num_cpu_accesses.checked_add(1)
+            .expect("Overflow in CPU accesses");
 
         CpuBufferPoolSubbuffer {
             buffer: self.buffer.clone(),
-            subbuffer_index: self.subbuffer_index,
-            size: self.size,
+            index: self.index,
+            len: self.len,
             marker: PhantomData,
         }
     }
 }
 
-unsafe impl<T: ?Sized, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
+unsafe impl<T, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     #[inline]
     fn inner(&self) -> BufferInner {
         BufferInner {
             buffer: &self.buffer.inner,
-            offset: self.subbuffer_index * self.size,
+            offset: self.index * mem::size_of::<T>(),
         }
     }
 
     #[inline]
     fn size(&self) -> usize {
-        self.size
+        self.len * mem::size_of::<T>()
     }
 
     #[inline]
-    fn conflict_key(&self, self_offset: usize, self_size: usize) -> u64 {
-        self.buffer.inner.key() + self.subbuffer_index as u64
+    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+        self.buffer.inner.key() + self.index as u64
     }
 
     #[inline]
     fn try_gpu_lock(&self, _: bool, _: &Queue) -> Result<(), AccessError> {
-        let in_use = &self.buffer.subbuffers[self.subbuffer_index].num_gpu_accesses;
-        if in_use.compare_and_swap(0, 1, Ordering::SeqCst) != 0 {
+        let mut chunks_in_use_lock = self.buffer.chunks_in_use.lock().unwrap();
+        let chunk = chunks_in_use_lock.iter_mut().find(|c| c.index == self.index).unwrap();
+
+        if chunk.num_gpu_accesses != 0 {
             return Err(AccessError::AlreadyInUse);
         }
 
+        chunk.num_gpu_accesses = 1;
         Ok(())
     }
 
     #[inline]
     unsafe fn increase_gpu_lock(&self) {
-        let in_use = &self.buffer.subbuffers[self.subbuffer_index];
-        let num_usages = in_use.num_gpu_accesses.fetch_add(1, Ordering::SeqCst);
-        debug_assert!(num_usages >= 1);
+        let mut chunks_in_use_lock = self.buffer.chunks_in_use.lock().unwrap();
+        let chunk = chunks_in_use_lock.iter_mut().find(|c| c.index == self.index).unwrap();
+
+        debug_assert!(chunk.num_gpu_accesses >= 1);
+        chunk.num_gpu_accesses = chunk.num_gpu_accesses.checked_add(1)
+            .expect("Overflow in GPU usages");
     }
 
     #[inline]
     unsafe fn unlock(&self) {
-        let in_use = &self.buffer.subbuffers[self.subbuffer_index];
-        let was_in_use = in_use.num_gpu_accesses.fetch_sub(1, Ordering::SeqCst);
-        debug_assert!(was_in_use >= 1);
+        let mut chunks_in_use_lock = self.buffer.chunks_in_use.lock().unwrap();
+        let chunk = chunks_in_use_lock.iter_mut().find(|c| c.index == self.index).unwrap();
+
+        debug_assert!(chunk.num_gpu_accesses >= 1);
+        chunk.num_gpu_accesses -= 1;
     }
 }
 
-impl<T: ?Sized, A> Drop for CpuBufferPoolSubbuffer<T, A>
+impl<T, A> Drop for CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     fn drop(&mut self) {
-        let in_use = &self.buffer.subbuffers[self.subbuffer_index];
-        let prev_val = in_use.num_cpu_accesses.fetch_sub(1, Ordering::SeqCst);
-        debug_assert!(prev_val >= 1);
+        let mut chunks_in_use_lock = self.buffer.chunks_in_use.lock().unwrap();
+        let chunk_num = chunks_in_use_lock.iter_mut().position(|c| c.index == self.index).unwrap();
+
+        if chunks_in_use_lock[chunk_num].num_cpu_accesses >= 2 {
+            chunks_in_use_lock[chunk_num].num_cpu_accesses -= 1;
+        } else {
+            debug_assert_eq!(chunks_in_use_lock[chunk_num].num_gpu_accesses, 0);
+            chunks_in_use_lock.remove(chunk_num);
+        }
     }
 }
 
-unsafe impl<T: ?Sized, A> TypedBufferAccess for CpuBufferPoolSubbuffer<T, A>
+unsafe impl<T, A> TypedBufferAccess for CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     type Content = T;
 }
 
-unsafe impl<T: ?Sized, A> DeviceOwned for CpuBufferPoolSubbuffer<T, A>
+unsafe impl<T, A> DeviceOwned for CpuBufferPoolSubbuffer<T, A>
     where A: MemoryPool
 {
     #[inline]

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -149,11 +149,20 @@ impl<T> CpuBufferPool<T> {
 
     /// Builds a `CpuBufferPool` meant for simple uploads.
     ///
-    /// Shortcut for a pool that can only be used as transfer sources and with exclusive queue
+    /// Shortcut for a pool that can only be used as transfer source and with exclusive queue
     /// family accesses.
     #[inline]
     pub fn upload(device: Arc<Device>) -> CpuBufferPool<T> {
         CpuBufferPool::new(device, BufferUsage::transfer_source(), iter::empty())
+    }
+
+    /// Builds a `CpuBufferPool` meant for simple downloads.
+    ///
+    /// Shortcut for a pool that can only be used as transfer destination and with exclusive queue
+    /// family accesses.
+    #[inline]
+    pub fn download(device: Arc<Device>) -> CpuBufferPool<T> {
+        CpuBufferPool::new(device, BufferUsage::transfer_destination(), iter::empty())
     }
 }
 


### PR DESCRIPTION
Can now allocate chunks from the `CpuBufferPool`, which means that it can now be used to stream data at each frame even when the data varies in size.