### PR TITLE
Use untagged unions in `vk-sys`

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -2103,6 +2103,7 @@ pub struct BufferImageCopy {
 }
 
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub union ClearColorValue {
     pub float32: [f32; 4],
     pub int32: [i32; 4],
@@ -2110,6 +2111,7 @@ pub union ClearColorValue {
 }
 
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct ClearDepthStencilValue {
     pub depth: f32,
     pub stencil: u32,

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+// TODO: remove once Rust 1.19 is stable.
+#![feature(untagged_unions)]
+
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
@@ -2103,16 +2106,10 @@ pub struct BufferImageCopy {
 }
 
 #[repr(C)]
-pub struct ClearColorValue([u32; 4]);
-
-impl ClearColorValue {
-    #[inline] pub fn as_float32(&self) -> &[f32; 4] { unsafe { mem::transmute(&self.0) } }
-    #[inline] pub fn as_int32(&self) -> &[i32; 4] { unsafe { mem::transmute(&self.0) } }
-    #[inline] pub fn as_uint32(&self) -> &[u32; 4] { &self.0 }
-
-    #[inline] pub fn float32(val: [f32; 4]) -> ClearColorValue { ClearColorValue(unsafe { mem::transmute(val) }) }
-    #[inline] pub fn int32(val: [i32; 4]) -> ClearColorValue { ClearColorValue(unsafe { mem::transmute(val) }) }
-    #[inline] pub fn uint32(val: [u32; 4]) -> ClearColorValue { ClearColorValue(val) }
+pub union ClearColorValue {
+    pub float32: [f32; 4],
+    pub int32: [i32; 4],
+    pub uint32: [u32; 4]
 }
 
 #[repr(C)]
@@ -2122,14 +2119,9 @@ pub struct ClearDepthStencilValue {
 }
 
 #[repr(C)]
-pub struct ClearValue(ClearColorValue);
-
-impl ClearValue {
-    #[inline] pub fn as_color(&self) -> &ClearColorValue { &self.0 }
-    #[inline] pub fn as_depth_stencil(&self) -> &ClearDepthStencilValue { unsafe { mem::transmute(&self.0) } }
-
-    #[inline] pub fn color(val: ClearColorValue) -> ClearValue { ClearValue(val) }
-    #[inline] pub fn depth_stencil(val: ClearDepthStencilValue) -> ClearValue { let val = (val, [0u32, 0u32]); ClearValue(unsafe { mem::transmute(val) }) }
+pub union ClearValue {
+    pub color: ClearColorValue,
+    pub depthStencil: ClearDepthStencilValue
 }
 
 #[repr(C)]

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -7,9 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-// TODO: remove once Rust 1.19 is stable.
-#![feature(untagged_unions)]
-
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -360,34 +360,34 @@ impl<P> UnsafeCommandBufferBuilder<P> {
         let raw_clear_values: SmallVec<[_; 12]> = clear_values
             .map(|clear_value| match clear_value {
                      ClearValue::None => {
-                         vk::ClearValue::color(vk::ClearColorValue::float32([0.0; 4]))
+                         vk::ClearValue { color: vk::ClearColorValue { float32: [0.0; 4] } }
                      },
                      ClearValue::Float(val) => {
-                         vk::ClearValue::color(vk::ClearColorValue::float32(val))
+                         vk::ClearValue { color: vk::ClearColorValue { float32: val } }
                      },
                      ClearValue::Int(val) => {
-                         vk::ClearValue::color(vk::ClearColorValue::int32(val))
+                         vk::ClearValue { color: vk::ClearColorValue { int32: val } }
                      },
                      ClearValue::Uint(val) => {
-                         vk::ClearValue::color(vk::ClearColorValue::uint32(val))
+                         vk::ClearValue { color: vk::ClearColorValue { uint32: val } }
                      },
                      ClearValue::Depth(val) => {
-                         vk::ClearValue::depth_stencil(vk::ClearDepthStencilValue {
+                         vk::ClearValue { depthStencil: vk::ClearDepthStencilValue {
                                                            depth: val,
                                                            stencil: 0,
-                                                       })
+                                                       }}
                      },
                      ClearValue::Stencil(val) => {
-                         vk::ClearValue::depth_stencil(vk::ClearDepthStencilValue {
+                         vk::ClearValue { depthStencil: vk::ClearDepthStencilValue {
                                                            depth: 0.0,
                                                            stencil: val,
-                                                       })
+                                                       }}
                      },
                      ClearValue::DepthStencil((depth, stencil)) => {
-                         vk::ClearValue::depth_stencil(vk::ClearDepthStencilValue {
+                         vk::ClearValue { depthStencil: vk::ClearDepthStencilValue {
                                                            depth: depth,
                                                            stencil: stencil,
-                                                       })
+                                                       }}
                      },
                  })
             .collect();
@@ -676,16 +676,16 @@ impl<P> UnsafeCommandBufferBuilder<P> {
 
         let color = match color {
             ClearValue::Float(val) => {
-                vk::ClearColorValue::float32(val)
+                vk::ClearColorValue { float32: val }
             },
             ClearValue::Int(val) => {
-                vk::ClearColorValue::int32(val)
+                vk::ClearColorValue { int32: val }
             },
             ClearValue::Uint(val) => {
-                vk::ClearColorValue::uint32(val)
+                vk::ClearColorValue { uint32: val }
             },
             _ => {
-                vk::ClearColorValue::float32([0.0; 4])
+                vk::ClearColorValue { float32: [0.0; 4] }
             },
         };
 


### PR DESCRIPTION
This pull request replaces the `ClearColorValue` and `ClearValue` `struct`s (which are declared as C `union`s in the spec) with Rust's new untagged `union`s. This is a feature currently available on nightly, and will be stabilized in Rust 1.19.

Fixes #664 (once Rust 1.19 is released, that is).