### PR TITLE
Correctly synchronize resources in descriptor sets

### DIFF
--- a/vulkano/src/command_buffer/synced.rs
+++ b/vulkano/src/command_buffer/synced.rs
@@ -448,7 +448,7 @@ impl<P> SyncCommandBufferBuilder<P> {
                     entry.access = access;
                     entry.exclusive_any = true;
                     entry.exclusive = exclusive;
-                    if exclusive {
+                    if exclusive || end_layout != ImageLayout::Undefined {
                         // Only modify the layout in case of a write, because buffer operations
                         // pass `Undefined` for the layout. While a buffer write *must* set the
                         // layout to `Undefined`, a buffer read must not touch it.

--- a/vulkano/src/descriptor/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor/descriptor_set/mod.rs
@@ -38,7 +38,7 @@
 use SafeDeref;
 use buffer::BufferAccess;
 use descriptor::descriptor::DescriptorDesc;
-use image::ImageAccess;
+use image::ImageViewAccess;
 
 pub use self::collection::DescriptorSetsCollection;
 pub use self::persistent::PersistentDescriptorSet;
@@ -94,7 +94,7 @@ pub unsafe trait DescriptorSet: DescriptorSetDesc {
     /// the index of the descriptor that uses this image.
     ///
     /// The valid range is between 0 and `num_images()`.
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)>;
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)>;
 }
 
 unsafe impl<T> DescriptorSet for T
@@ -122,7 +122,7 @@ unsafe impl<T> DescriptorSet for T
     }
     
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         (**self).image(index)
     }
 }

--- a/vulkano/src/descriptor/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor/descriptor_set/mod.rs
@@ -78,13 +78,23 @@ pub unsafe trait DescriptorSet: DescriptorSetDesc {
     /// Returns the inner `UnsafeDescriptorSet`.
     fn inner(&self) -> &UnsafeDescriptorSet;
 
-    /// Returns the list of buffers used by this descriptor set. Includes buffer views.
-    // TODO: meh for boxing
-    fn buffers_list<'a>(&'a self) -> Box<Iterator<Item = &'a BufferAccess> + 'a>;
+    /// Returns the number of buffers within this descriptor set.
+    fn num_buffers(&self) -> usize;
+    
+    /// Returns the `index`th buffer of this descriptor set, or `None` if out of range. Also
+    /// returns the index of the descriptor that uses this buffer.
+    ///
+    /// The valid range is between 0 and `num_buffers()`.
+    fn buffer(&self, index: usize) -> Option<(&BufferAccess, u32)>;
 
-    /// Returns the list of images used by this descriptor set. Includes image views.
-    // TODO: meh for boxing
-    fn images_list<'a>(&'a self) -> Box<Iterator<Item = &'a ImageAccess> + 'a>;
+    /// Returns the number of images within this descriptor set.
+    fn num_images(&self) -> usize;
+    
+    /// Returns the `index`th image of this descriptor set, or `None` if out of range. Also returns
+    /// the index of the descriptor that uses this image.
+    ///
+    /// The valid range is between 0 and `num_images()`.
+    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)>;
 }
 
 unsafe impl<T> DescriptorSet for T
@@ -97,13 +107,23 @@ unsafe impl<T> DescriptorSet for T
     }
 
     #[inline]
-    fn buffers_list<'a>(&'a self) -> Box<Iterator<Item = &'a BufferAccess> + 'a> {
-        (**self).buffers_list()
+    fn num_buffers(&self) -> usize {
+        (**self).num_buffers()
+    }
+    
+    #[inline]
+    fn buffer(&self, index: usize) -> Option<(&BufferAccess, u32)> {
+        (**self).buffer(index)
     }
 
     #[inline]
-    fn images_list<'a>(&'a self) -> Box<Iterator<Item = &'a ImageAccess> + 'a> {
-        (**self).images_list()
+    fn num_images(&self) -> usize {
+        (**self).num_images()
+    }
+    
+    #[inline]
+    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+        (**self).image(index)
     }
 }
 

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -31,7 +31,6 @@ use descriptor::pipeline_layout::PipelineLayoutAbstract;
 use device::Device;
 use device::DeviceOwned;
 use format::Format;
-use image::ImageAccess;
 use image::ImageViewAccess;
 use sampler::Sampler;
 use OomError;
@@ -113,7 +112,7 @@ unsafe impl<L, R, P> DescriptorSet for PersistentDescriptorSet<L, R, P>
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         self.resources.image(index)
     }
 }
@@ -774,7 +773,7 @@ pub unsafe trait PersistentDescriptorSetResources {
     fn num_buffers(&self) -> usize;
     fn buffer(&self, index: usize) -> Option<(&BufferAccess, u32)>;
     fn num_images(&self) -> usize;
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)>;
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)>;
 }
 
 unsafe impl PersistentDescriptorSetResources for () {
@@ -794,7 +793,7 @@ unsafe impl PersistentDescriptorSetResources for () {
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         None
     }
 }
@@ -831,7 +830,7 @@ unsafe impl<R, B> PersistentDescriptorSetResources for (R, PersistentDescriptorS
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         self.0.image(index)
     }
 }
@@ -870,7 +869,7 @@ unsafe impl<R, V> PersistentDescriptorSetResources for (R, PersistentDescriptorS
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         self.0.image(index)
     }
 }
@@ -883,7 +882,7 @@ pub struct PersistentDescriptorSetImg<I> {
 
 unsafe impl<R, I> PersistentDescriptorSetResources for (R, PersistentDescriptorSetImg<I>)
     where R: PersistentDescriptorSetResources,
-          I: ImageAccess,
+          I: ImageViewAccess,
 {
     #[inline]
     fn num_buffers(&self) -> usize {
@@ -901,7 +900,7 @@ unsafe impl<R, I> PersistentDescriptorSetResources for (R, PersistentDescriptorS
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         if let Some(img) = self.0.image(index) {
             Some(img)
         } else if index == self.0.num_images() {
@@ -936,7 +935,7 @@ unsafe impl<R> PersistentDescriptorSetResources for (R, PersistentDescriptorSetS
     }
 
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         self.0.image(index)
     }
 }

--- a/vulkano/src/descriptor/descriptor_set/simple.rs
+++ b/vulkano/src/descriptor/descriptor_set/simple.rs
@@ -28,7 +28,6 @@ use descriptor::descriptor_set::UnsafeDescriptorSetLayout;
 use descriptor::pipeline_layout::PipelineLayoutAbstract;
 use device::Device;
 use device::DeviceOwned;
-use image::ImageAccess;
 use image::ImageLayout;
 use image::ImageViewAccess;
 use sampler::Sampler;
@@ -102,7 +101,7 @@ unsafe impl<R, P> DescriptorSet for SimpleDescriptorSet<R, P>
     }
     
     #[inline]
-    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+    fn image(&self, index: usize) -> Option<(&ImageViewAccess, u32)> {
         // Note that since the simple descriptor set is deprecated, and since buffers and images
         // within descriptor sets weren't supported before its deprecation, we just return a dummy
         // value.

--- a/vulkano/src/descriptor/descriptor_set/simple.rs
+++ b/vulkano/src/descriptor/descriptor_set/simple.rs
@@ -78,13 +78,35 @@ unsafe impl<R, P> DescriptorSet for SimpleDescriptorSet<R, P>
     }
 
     #[inline]
-    fn buffers_list<'a>(&'a self) -> Box<Iterator<Item = &'a BufferAccess> + 'a> {
-        unimplemented!()
+    fn num_buffers(&self) -> usize {
+        // Note that since the simple descriptor set is deprecated, and since buffers and images
+        // within descriptor sets weren't supported before its deprecation, we just return a dummy
+        // value.
+        0
+    }
+    
+    #[inline]
+    fn buffer(&self, index: usize) -> Option<(&BufferAccess, u32)> {
+        // Note that since the simple descriptor set is deprecated, and since buffers and images
+        // within descriptor sets weren't supported before its deprecation, we just return a dummy
+        // value.
+        None
     }
 
     #[inline]
-    fn images_list<'a>(&'a self) -> Box<Iterator<Item = &'a ImageAccess> + 'a> {
-        unimplemented!()
+    fn num_images(&self) -> usize {
+        // Note that since the simple descriptor set is deprecated, and since buffers and images
+        // within descriptor sets weren't supported before its deprecation, we just return a dummy
+        // value.
+        0
+    }
+    
+    #[inline]
+    fn image(&self, index: usize) -> Option<(&ImageAccess, u32)> {
+        // Note that since the simple descriptor set is deprecated, and since buffers and images
+        // within descriptor sets weren't supported before its deprecation, we just return a dummy
+        // value.
+        None
     }
 }
 


### PR DESCRIPTION
Before this PR the buffers and images used in descriptor sets weren't taken into account at all for pipeline barriers and image transitions. This fixes it.

This PR also prevents pipeline barriers from happening within a render pass. The Vulkan specs allow them under very specific conditions, but that will be for another day.

I basically went "full C" in this PR. I'm not sure that everything is correct, but it looks like it works and doesn't trigger any validation error.
