### PR TITLE
Ignore errors when destroying a present future

### DIFF
--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1052,11 +1052,17 @@ impl<P> Drop for PresentFuture<P>
     fn drop(&mut self) {
         unsafe {
             if !*self.finished.get_mut() {
-                // TODO: handle errors?
-                self.flush().unwrap();
-                // Block until the queue finished.
-                self.queue().unwrap().wait().unwrap();
-                self.previous.signal_finished();
+                match self.flush() {
+                    Ok(()) => {
+                        // Block until the queue finished.
+                        self.queue().unwrap().wait().unwrap();
+                        self.previous.signal_finished();
+                    },
+                    Err(_) => {
+                        // In case of error we simply do nothing, as there's nothing to do
+                        // anyway.
+                    },
+                }
             }
         }
     }


### PR DESCRIPTION
The problem is that user code typically does this:

```rust
match future.flush() {
    Ok(()) => (),
    Err(OutOfDate) => { recreate_swapchain = true; continue; }
    Err(err) => panic!()
}
```

But if `flush` returns `OutOfDate`, then continuing will drop the future and panic in the destructor.
This code ignores errors in the destructor in order to avoid that.

I feel like destroying futures needs some more thoughts.