### PR TITLE
fixes #645 Returning `Result<(), OomError>` for `reset` and `multi_reset`

### DIFF
--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -430,7 +430,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let mut fence = Fence::alloc_signaled(device.clone()).unwrap();
-        fence.reset();
+        fence.reset().unwrap();
         assert!(!fence.ready().unwrap());
     }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -430,9 +430,8 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let mut fence = Fence::alloc_signaled(device.clone()).unwrap();
-        if (fence.reset().is_ok()) {
-            assert!(!fence.ready().unwrap());
-        }
+        fence.reset();
+        assert!(!fence.ready().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
fixes #645 Returning `Result<(), OomError>` for `reset` and `multi_reset`

Im not sure if that is the correct way to handle the else in line 314 in `multi_reset` or if there is another way more `idiomatic`.