### PR TITLE
Macos updates

### DIFF
--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -12,6 +12,6 @@ vulkano = { version = "0.5.0", path = "../vulkano" }
 winit = "0.7.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal-rs = "0.3.0"
-cocoa = "0.8.1"
+metal-rs = "0.4"
+cocoa = "0.9"
 objc = "0.2"

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -179,19 +179,17 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: &winit::Window)
                            -> Result<Arc<Surface>, SurfaceCreationError> {
     use winit::os::macos::WindowExt;
 
-    unsafe {
-        let wnd: cocoa_id = mem::transmute(win.get_nswindow());
+    let wnd: cocoa_id = mem::transmute(win.get_nswindow());
 
-        let layer = CAMetalLayer::new();
+    let layer = CAMetalLayer::new();
 
-        layer.set_edge_antialiasing_mask(0);
-        layer.set_presents_with_transaction(false);
-        layer.remove_all_animations();
+    layer.set_edge_antialiasing_mask(0);
+    layer.set_presents_with_transaction(false);
+    layer.remove_all_animations();
 
-        let view = wnd.contentView();
-        view.setWantsLayer(YES);
-        view.setLayer(mem::transmute(layer.0)); // Bombs here with out of memory
-    }
+    let view = wnd.contentView();
+    view.setWantsLayer(YES);
+    view.setLayer(mem::transmute(layer.0)); // Bombs here with out of memory
 
     Surface::from_macos_moltenvk(instance, win.get_nsview() as *const ())
 }


### PR DESCRIPTION
This PR does two things:
1. Update dependencies on macos
2. Removes an unnessecary unsafe block, which was emitting a compile warning