### PR TITLE
Add Instance::with_loader

### DIFF
--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -182,7 +182,7 @@ macro_rules! instance_extensions {
         impl $rawname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
-                let entry_points = try!(loader::entry_points());
+                let entry_points = try!(loader::default_function_pointers()).entry_points();
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
                     let mut num = 0;
@@ -211,7 +211,7 @@ macro_rules! instance_extensions {
         impl $sname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
-                let entry_points = try!(loader::entry_points());
+                let entry_points = try!(loader::default_function_pointers()).entry_points();
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
                     let mut num = 0;

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -182,7 +182,15 @@ macro_rules! instance_extensions {
         impl $rawname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
-                let entry_points = try!(loader::default_function_pointers()).entry_points();
+                $rawname::supported_by_core_raw_with_loader(loader::auto_loader()?)
+            }
+
+            /// Same as `supported_by_core_raw()`, but allows specifying a loader.
+            pub fn supported_by_core_raw_with_loader<L>(ptrs: &loader::FunctionPointers<L>)
+                        -> Result<Self, SupportedExtensionsError>
+                where L: loader::Loader
+            {
+                let entry_points = ptrs.entry_points();
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
                     let mut num = 0;
@@ -206,12 +214,32 @@ macro_rules! instance_extensions {
                     Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),
                 }
             }
+
+            /// Same as `supported_by_core`, but allows specifying a loader.
+            pub fn supported_by_core_with_loader<L>(ptrs: &loader::FunctionPointers<L>)
+                        -> Result<Self, LoadingError>
+                where L: loader::Loader
+            {
+                match $rawname::supported_by_core_raw_with_loader(ptrs) {
+                    Ok(l) => Ok(l),
+                    Err(SupportedExtensionsError::LoadingError(e)) => Err(e),
+                    Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),
+                }
+            }
         }
 
         impl $sname {
             /// See the docs of supported_by_core().
             pub fn supported_by_core_raw() -> Result<Self, SupportedExtensionsError> {
-                let entry_points = try!(loader::default_function_pointers()).entry_points();
+                $sname::supported_by_core_raw_with_loader(loader::auto_loader()?)
+            }
+
+            /// See the docs of supported_by_core().
+            pub fn supported_by_core_raw_with_loader<L>(ptrs: &loader::FunctionPointers<L>)
+                        -> Result<Self, SupportedExtensionsError>
+                where L: loader::Loader
+            {
+                let entry_points = ptrs.entry_points();
 
                 let properties: Vec<vk::ExtensionProperties> = unsafe {
                     let mut num = 0;
@@ -241,6 +269,18 @@ macro_rules! instance_extensions {
             /// Returns a `RawExtensions` object with extensions supported by the core driver.
             pub fn supported_by_core() -> Result<Self, LoadingError> {
                 match $sname::supported_by_core_raw() {
+                    Ok(l) => Ok(l),
+                    Err(SupportedExtensionsError::LoadingError(e)) => Err(e),
+                    Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),
+                }
+            }
+
+            /// Same as `supported_by_core`, but allows specifying a loader.
+            pub fn supported_by_core_with_loader<L>(ptrs: &loader::FunctionPointers<L>)
+                        -> Result<Self, LoadingError>
+                where L: loader::Loader
+            {
+                match $sname::supported_by_core_raw_with_loader(ptrs) {
                     Ok(l) => Ok(l),
                     Err(SupportedExtensionsError::LoadingError(e)) => Err(e),
                     Err(SupportedExtensionsError::OomError(e)) => panic!("{:?}", e),

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -92,6 +92,10 @@ pub struct Instance {
     function_pointers: OwnedOrRef<FunctionPointers<Box<Loader + Send + Sync>>>,
 }
 
+// TODO: fix the underlying cause instead
+impl ::std::panic::UnwindSafe for Instance {}
+impl ::std::panic::RefUnwindSafe for Instance {}
+
 impl Instance {
     /// Initializes a new instance of Vulkan.
     ///

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -129,7 +129,7 @@ impl Instance {
             .collect::<SmallVec<[_; 16]>>();
 
         Instance::new_inner(app_infos, extensions.into(), layers,
-                            OwnedOrRef::Ref(loader::default_function_pointers()?))
+                            OwnedOrRef::Ref(loader::auto_loader()?))
     }
 
     /// Same as `new`, but allows specifying a loader where to load Vulkan from.

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -14,6 +14,7 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::fmt;
 use std::mem;
+use std::ops::Deref;
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
@@ -23,6 +24,8 @@ use OomError;
 use VulkanObject;
 use check_errors;
 use instance::loader;
+use instance::loader::FunctionPointers;
+use instance::loader::Loader;
 use instance::loader::LoadingError;
 use vk;
 
@@ -86,6 +89,7 @@ pub struct Instance {
     vk: vk::InstancePointers,
     extensions: InstanceExtensions,
     layers: SmallVec<[CString; 16]>,
+    function_pointers: OwnedOrRef<FunctionPointers<Box<Loader + Send + Sync>>>,
 }
 
 impl Instance {
@@ -124,11 +128,13 @@ impl Instance {
             .map(|&layer| CString::new(layer).unwrap())
             .collect::<SmallVec<[_; 16]>>();
 
-        Instance::new_inner(app_infos, extensions.into(), layers)
+        Instance::new_inner(app_infos, extensions.into(), layers,
+                            OwnedOrRef::Ref(loader::default_function_pointers()?))
     }
 
     fn new_inner(app_infos: Option<&ApplicationInfo>, extensions: RawInstanceExtensions,
-                 layers: SmallVec<[CString; 16]>)
+                 layers: SmallVec<[CString; 16]>,
+                 function_pointers: OwnedOrRef<FunctionPointers<Box<Loader + Send + Sync>>>)
                  -> Result<Arc<Instance>, InstanceCreationError> {
         // TODO: For now there are still buggy drivers that will segfault if you don't pass any
         //       appinfos. Therefore for now we ensure that it can't be `None`.
@@ -202,8 +208,6 @@ impl Instance {
             .map(|extension| extension.as_ptr())
             .collect::<SmallVec<[_; 32]>>();
 
-        let entry_points = loader::entry_points()?;
-
         // Creating the Vulkan instance.
         let instance = unsafe {
             let mut output = mem::uninitialized();
@@ -222,17 +226,16 @@ impl Instance {
                 ppEnabledExtensionNames: extensions_list.as_ptr(),
             };
 
+            let entry_points = function_pointers.entry_points();
             check_errors(entry_points.CreateInstance(&infos, ptr::null(), &mut output))?;
             output
         };
 
         // Loading the function pointers of the newly-created instance.
         let vk = {
-            let f = loader::static_functions()?;
             vk::InstancePointers::load(|name| unsafe {
-                                           mem::transmute(f.GetInstanceProcAddr(instance,
-                                                                                name.as_ptr()))
-                                       })
+                mem::transmute(function_pointers.get_instance_proc_addr(instance, name.as_ptr()))
+            })
         };
 
         // Enumerating all physical devices.
@@ -264,6 +267,7 @@ impl Instance {
                         vk: vk,
                         extensions: extensions,
                         layers: layers,
+                        function_pointers: function_pointers,
                     }))
     }
 
@@ -448,6 +452,23 @@ impl Drop for Instance {
     fn drop(&mut self) {
         unsafe {
             self.vk.DestroyInstance(self.instance, ptr::null());
+        }
+    }
+}
+
+// Same as Cow but less annoying.
+enum OwnedOrRef<T: 'static> {
+    Owned(T),
+    Ref(&'static T),
+}
+
+impl<T> Deref for OwnedOrRef<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        match *self {
+            OwnedOrRef::Owned(ref v) => v,
+            OwnedOrRef::Ref(v) => v,
         }
     }
 }

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -132,6 +132,22 @@ impl Instance {
                             OwnedOrRef::Ref(loader::default_function_pointers()?))
     }
 
+    /// Same as `new`, but allows specifying a loader where to load Vulkan from.
+    pub fn with_loader<'a, L, Ext>(loader: FunctionPointers<Box<Loader + Send + Sync>>,
+                                   app_infos: Option<&ApplicationInfo>, extensions: Ext,
+                                   layers: L) -> Result<Arc<Instance>, InstanceCreationError>
+        where L: IntoIterator<Item = &'a &'a str>,
+              Ext: Into<RawInstanceExtensions>
+    {
+        let layers = layers
+            .into_iter()
+            .map(|&layer| CString::new(layer).unwrap())
+            .collect::<SmallVec<[_; 16]>>();
+
+        Instance::new_inner(app_infos, extensions.into(), layers,
+                            OwnedOrRef::Owned(loader))
+    }
+
     fn new_inner(app_infos: Option<&ApplicationInfo>, extensions: RawInstanceExtensions,
                  layers: SmallVec<[CString; 16]>,
                  function_pointers: OwnedOrRef<FunctionPointers<Box<Loader + Send + Sync>>>)

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -45,8 +45,16 @@ use vk;
 /// }
 /// ```
 pub fn layers_list() -> Result<LayersIterator, LayersListError> {
+    layers_list_from_loader(loader::auto_loader()?)
+}
+
+/// Same as `layers_list()`, but allows specifying a loader.
+pub fn layers_list_from_loader<L>(ptrs: &loader::FunctionPointers<L>)
+                                  -> Result<LayersIterator, LayersListError>
+    where L: loader::Loader
+{
     unsafe {
-        let entry_points = loader::default_function_pointers()?.entry_points();
+        let entry_points = ptrs.entry_points();
 
         let mut num = 0;
         check_errors({

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -46,7 +46,7 @@ use vk;
 /// ```
 pub fn layers_list() -> Result<LayersIterator, LayersListError> {
     unsafe {
-        let entry_points = loader::entry_points()?;
+        let entry_points = loader::default_function_pointers()?.entry_points();
 
         let mut num = 0;
         check_errors({

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -252,3 +252,19 @@ impl fmt::Display for LoadingError {
         write!(fmt, "{}", error::Error::description(self))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use instance::loader::DynamicLibraryLoader;
+    use instance::loader::LoadingError;
+
+    #[test]
+    fn dl_open_error() {
+        unsafe {
+            match DynamicLibraryLoader::new("_non_existing_library.void") {
+                Err(LoadingError::LibraryLoadFailure(_)) => (),
+                _ => panic!()
+            }
+        }
+    }
+}

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -62,8 +62,8 @@ impl DynamicLibraryLoader {
 
         let get_proc_addr = {
             let ptr: *mut c_void = vk_lib
-                .symbol("GetInstanceProcAddr")
-                .map_err(|_| LoadingError::MissingEntryPoint("GetInstanceProcAddr".to_owned()))?;
+                .symbol("vkGetInstanceProcAddr")
+                .map_err(|_| LoadingError::MissingEntryPoint("vkGetInstanceProcAddr".to_owned()))?;
             mem::transmute(ptr)
         };
 

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -10,96 +10,160 @@
 use std::error;
 use std::fmt;
 use std::mem;
+use std::ops::Deref;
+use std::os::raw::c_char;
+use std::os::raw::c_void;
 
+use SafeDeref;
 use vk;
+
+/// Implemented on objects that grant access to a Vulkan implementation.
+pub unsafe trait Loader {
+    /// Calls the `vkGetInstanceProcAddr` function. The parameters are the same.
+    ///
+    /// The returned function must stay valid for as long as `self` is alive.
+    fn get_instance_proc_addr(&self, instance: vk::Instance, name: *const c_char)
+                              -> extern "system" fn() -> ();
+}
+
+unsafe impl<T> Loader for T
+    where T: SafeDeref,
+          T::Target: Loader
+{
+    #[inline]
+    fn get_instance_proc_addr(&self, instance: vk::Instance, name: *const c_char)
+                              -> extern "system" fn() -> () {
+        (**self).get_instance_proc_addr(instance, name)
+    }
+}
+
+/// Wraps around a loader and contains function pointers.
+pub struct FunctionPointers<L> {
+    loader: L,
+    entry_points: vk::EntryPoints,
+}
+
+impl<L> FunctionPointers<L> {
+    /// Loads some global function pointer from the loader.
+    pub fn new(loader: L) -> FunctionPointers<L>
+        where L: Loader
+    {
+        let entry_points = vk::EntryPoints::load(|name| {
+            unsafe {
+                mem::transmute(loader.get_instance_proc_addr(0, name.as_ptr()))
+            }
+        });
+
+        FunctionPointers {
+            loader,
+            entry_points,
+        }
+    }
+
+    /// Returns the collection of Vulkan entry points from the Vulkan loader.
+    #[inline]
+    pub(crate) fn entry_points(&self) -> &vk::EntryPoints {
+        &self.entry_points
+    }
+
+    /// Calls `get_instance_proc_addr` on the underlying loader.
+    #[inline]
+    pub fn get_instance_proc_addr(&self, instance: vk::Instance, name: *const c_char)
+                                  -> extern "system" fn() -> ()
+        where L: Loader
+    {
+        self.loader.get_instance_proc_addr(instance, name)
+    }
+}
+
+/// Returns the default `FunctionPointers` for this system.
+///
+/// This function tries to auto-guess where to find the Vulkan implementation, and loads it in a
+/// `lazy_static!`. The content of the lazy_static is then returned, or an error if we failed to
+/// load Vulkan.
+pub fn default_function_pointers()
+    -> Result<&'static FunctionPointers<Box<Loader + Send + Sync>>, LoadingError>
+{
+    lazy_static! {
+        static ref DEFAULT_LOADER: Result<FunctionPointers<Box<Loader + Send + Sync>>, LoadingError> = {
+            def_loader_impl().map(FunctionPointers::new)
+        };
+    }
+
+    match DEFAULT_LOADER.deref() {
+        &Ok(ref ptr) => Ok(ptr),
+        &Err(ref err) => Err(err.clone())
+    }
+}
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[allow(non_snake_case)]
-fn load_static() -> Result<vk::Static, LoadingError> {
-    use std::os::raw::c_char;
-
+fn def_loader_impl() -> Result<Box<Loader + Send + Sync>, LoadingError> {
     extern "C" {
         fn vkGetInstanceProcAddr(instance: vk::Instance, pName: *const c_char)
                                  -> vk::PFN_vkVoidFunction;
     }
 
-    extern "system" fn wrapper(instance: vk::Instance, pName: *const c_char)
-                               -> vk::PFN_vkVoidFunction {
-        unsafe { vkGetInstanceProcAddr(instance, pName) }
+    struct LoaderImpl;
+    unsafe impl Loader for LoaderImpl {
+        fn get_instance_proc_addr(&self, instance: vk::Instance, name: *const c_char)
+                                  -> extern "system" fn() -> () {
+            unsafe { vkGetInstanceProcAddr(instance, name) }
+        }
     }
 
-    Ok(vk::Static { GetInstanceProcAddr: wrapper })
+    Ok(Box::new(LoaderImpl))
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-fn load_static() -> Result<vk::Static, LoadingError> {
+fn def_loader_impl() -> Result<Box<Loader + Send + Sync>, LoadingError> {
     use std::path::Path;
-    use std::ptr;
     use shared_library;
-    lazy_static! {
-        static ref VK_LIB: Result<shared_library::dynamic_library::DynamicLibrary, LoadingError> = {
-            #[cfg(windows)] fn get_path() -> &'static Path { Path::new("vulkan-1.dll") }
-            #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))] fn get_path() -> &'static Path { Path::new("libvulkan.so.1") }
-            #[cfg(target_os = "android")] fn get_path() -> &'static Path { Path::new("libvulkan.so") }
-            let path = get_path();
-            shared_library::dynamic_library::DynamicLibrary::open(Some(path))
-                                        .map_err(|err| LoadingError::LibraryLoadFailure(err))
-        };
-    }
 
-    match *VK_LIB {
-        Ok(ref lib) => {
-            let mut err = None;
-            let result = vk::Static::load(|name| unsafe {
-                let name = name.to_str().unwrap();
-                match lib.symbol(name) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        // TODO: return error?
-                        err = Some(LoadingError::MissingEntryPoint(name.to_owned()));
-                        ptr::null()
-                    },
-                }
-            });
-
-            if let Some(err) = err {
-                Err(err)
-            } else {
-                Ok(result)
-            }
-        },
-        Err(ref err) => Err(err.clone()),
-    }
-}
-
-lazy_static! {
-    static ref VK_STATIC: Result<vk::Static, LoadingError> = load_static();
-
-    static ref VK_ENTRY: Result<vk::EntryPoints, LoadingError> = {
-        match *VK_STATIC {
-            Ok(ref lib) => {
-                // At this point we assume that if one of the functions fails to load, it is an
-                // implementation bug and not a real-life situation that could be handled by
-                // an error.
-                Ok(vk::EntryPoints::load(|name| unsafe {
-                    mem::transmute(lib.GetInstanceProcAddr(0, name.as_ptr()))
-                }))
-            },
-            Err(ref err) => Err(err.clone()),
+    let vk_lib = {
+        #[cfg(windows)]
+        fn get_path() -> &'static Path {
+            Path::new("vulkan-1.dll")
         }
+        #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
+        fn get_path() -> &'static Path {
+            Path::new("libvulkan.so.1")
+        }
+        #[cfg(target_os = "android")]
+        fn get_path() -> &'static Path {
+            Path::new("libvulkan.so")
+        }
+        let path = get_path();
+
+        shared_library::dynamic_library::DynamicLibrary::open(Some(path))
+            .map_err(LoadingError::LibraryLoadFailure)?
     };
-}
 
-/// Returns the collection of static functions from the Vulkan loader, or an error if failed to
-/// open the loader.
-pub fn static_functions() -> Result<&'static vk::Static, LoadingError> {
-    VK_STATIC.as_ref().map_err(|err| err.clone())
-}
+    let get_proc_addr = unsafe {
+        let ptr: *mut c_void = vk_lib
+            .symbol("GetInstanceProcAddr")
+            .map_err(|_| LoadingError::MissingEntryPoint("GetInstanceProcAddr".to_owned()))?;
+        mem::transmute(ptr)
+    };
 
-/// Returns the collection of Vulkan entry points from the Vulkan loader, or an error if failed to
-/// open the loader.
-pub fn entry_points() -> Result<&'static vk::EntryPoints, LoadingError> {
-    VK_ENTRY.as_ref().map_err(|err| err.clone())
+    struct LoaderImpl {
+        vk_lib: shared_library::dynamic_library::DynamicLibrary,
+        get_proc_addr: extern "system" fn(instance: vk::Instance, pName: *const c_char)
+                                          -> extern "system" fn() -> (),
+    }
+
+    unsafe impl Loader for LoaderImpl {
+        #[inline]
+        fn get_instance_proc_addr(&self, instance: vk::Instance, name: *const c_char)
+                                  -> extern "system" fn() -> () {
+            (self.get_proc_addr)(instance, name)
+        }
+    }
+
+    Ok(Box::new(LoaderImpl {
+                    vk_lib,
+                    get_proc_addr,
+                }))
 }
 
 /// Error that can happen when loading the Vulkan loader.

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -7,6 +7,20 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! Vulkan implementation loading system.
+//! 
+//! Before vulkano can do anything, it first needs to find an implementation of Vulkan. A Vulkan
+//! implementation is defined as a single `vkGetInstanceProcAddr` function, which can be accessed
+//! through the `Loader` trait.
+//! 
+//! This module provides various implementations of the `Loader` trait.
+//! 
+//! Once you have a struct that implements `Loader`, you can create a `FunctionPointers` struct
+//! from it and use this `FunctionPointers` struct to build an `Instance`.
+//! 
+//! By default vulkano will use the `auto_loader()` function, which tries to automatically load
+//! a Vulkan implementation from the system.
+
 use std::error;
 use std::fmt;
 use std::mem;
@@ -129,6 +143,7 @@ impl<L> FunctionPointers<L> {
 ///
 /// This is provided as a macro and not as a regular function, because the macro contains an
 /// `extern {}` block.
+// TODO: should this be unsafe?
 #[macro_export]
 macro_rules! statically_linked_vulkan_loader {
     () => ({
@@ -154,7 +169,7 @@ macro_rules! statically_linked_vulkan_loader {
 /// This function tries to auto-guess where to find the Vulkan implementation, and loads it in a
 /// `lazy_static!`. The content of the lazy_static is then returned, or an error if we failed to
 /// load Vulkan.
-pub fn default_function_pointers()
+pub fn auto_loader()
     -> Result<&'static FunctionPointers<Box<Loader + Send + Sync>>, LoadingError>
 {
     #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
Fix #361 

Reworks the loading system.
- Adds a `Loader` trait with only one method that is the equivalent of `vkGetInstanceProcAddr`.
- Provides two implementations of `Loader`: `DynamicLibraryLoader` and `statically_linked_vulkan_loader!`.
- The loader can now be owned by the `Instance` instead of always being stored in a `lazy_static!`.
- Adds various methods to allow using a custom loader.

It would be nice if someone on OSX could try if it still works.